### PR TITLE
Fortuneo: append transactions

### DIFF
--- a/tx/pipelines.py
+++ b/tx/pipelines.py
@@ -381,6 +381,26 @@ class FortuneoTransactionPipeline(TransactionPipeline):
         ]
         return tx
 
+    def append_transactions(self, csv: Path, new_transactions: DataFrame):
+        df = new_transactions.copy()
+        cols = [
+            "Date",
+            "Label",
+            "Amount",
+            "Type",
+            "MainCategory",
+            "SubCategory",
+            "IsRegular",
+        ]
+
+        if csv.exists():
+            existing = pd.read_csv(csv, parse_dates=["Date"])
+            df = df.append(existing, sort=False)
+
+        df = df.drop_duplicates(subset=["Date", "Label", "Amount"], keep="last")
+        df = df.sort_values(by=["Date", "Label"])
+        df.to_csv(csv, columns=cols, index=None, date_format="%Y-%m-%d")
+
 
 class AccountParser:
     def __init__(self, cfg: Configuration):


### PR DESCRIPTION
Append new transactions into existing Fortuneo history.


```
CSV downloaded                    Pandas                  Finance Toolkit
from Fortuneo  --------------->  DataFrame -------------> Transactions
                                      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
                                         Implementation of this PR
```

This is part of #3 