### PR TITLE
Fix accountBalance format and file encoding

### DIFF
--- a/docs/boursorama.md
+++ b/docs/boursorama.md
@@ -1,0 +1,11 @@
+# Boursorama
+
+<https://www.boursorama.com/>
+
+## Data Specification
+
+| Item | Value | Description |
+| ---- | ----- | ----------- |
+| File encoding | UTF-8 | |
+| File type | CSV (`*.csv`) | |
+| File name | `export-operations-{dd}-{MM}-{yyyy}_{hh}-{mm}-{ss}.csv` | The data of all the accounts are grouped into one single CSV file. |

--- a/finance_toolkit/boursorama.py
+++ b/finance_toolkit/boursorama.py
@@ -51,7 +51,7 @@ class BoursoramaPipeline(Pipeline, metaclass=ABCMeta):
                 # uses ',' as decimal, so we handle the parsing ourselves.
                 "accountbalance": "str",
             },
-            "encoding": "ISO-8859-1",
+            "encoding": "UTF-8",
             "parse_dates": ["dateOp", "dateVal"],
             "skipinitialspace": True,
             "thousands": " ",

--- a/test/download/export-operations-11-06-2022_09-52-55.csv
+++ b/test/download/export-operations-11-06-2022_09-52-55.csv
@@ -1,0 +1,2 @@
+dateOp;dateVal;label;category;categoryParent;amount;comment;accountNum;accountLabel;accountbalance
+2021-08-17;2021-08-17;"Prime Parrainage";"Virements reçus";"Virements reçus";130,00;;001234;"BOURSORAMA BANQUE";226.68

--- a/test/download/export-operations-30-03-2019_08-50-51.csv
+++ b/test/download/export-operations-30-03-2019_08-50-51.csv
@@ -1,5 +1,5 @@
 dateOp;dateVal;label;category;categoryParent;amount;accountNum;accountLabel;accountbalance
-2019-03-12;2019-03-12;"Prime Parrainage";"Virements re�us";"Virements re�us";80,00;001234;"BOURSORAMA BANQUE";370.00
-2019-03-12;2019-03-12;"VIR VIREMENT CREATION COMPTE";"Virements re�us";"Virements re�us";300,00;001234;"BOURSORAMA BANQUE";370.00
-2019-03-12;2019-03-12;"VIR VIREMENT CREATION COMPTE";"Virements �mis de comptes � comptes";"Mouvements internes d�biteurs";-10,00;001234;"BOURSORAMA BANQUE";370.00
-2019-03-12;2019-03-12;"VIR VIREMENT CREATION COMPTE";"Virements re�us de comptes � comptes";"Mouvements internes cr�diteurs";10,00;003607;"COMPTE SUR LIVRET";4810.00
+2019-03-12;2019-03-12;"Prime Parrainage";"Virements reçus";"Virements reçus";80,00;001234;"BOURSORAMA BANQUE";370.00
+2019-03-12;2019-03-12;"VIR VIREMENT CREATION COMPTE";"Virements reçus";"Virements reçus";300,00;001234;"BOURSORAMA BANQUE";370.00
+2019-03-12;2019-03-12;"VIR VIREMENT CREATION COMPTE";"Virements émis de comptes à comptes";"Mouvements internes débiteurs";-10,00;001234;"BOURSORAMA BANQUE";370.00
+2019-03-12;2019-03-12;"VIR VIREMENT CREATION COMPTE";"Virements reçus de comptes à comptes";"Mouvements internes créditeurs";10,00;003607;"COMPTE SUR LIVRET";4810.00

--- a/test/download/export-operations-30-03-2019_08-50-51.csv
+++ b/test/download/export-operations-30-03-2019_08-50-51.csv
@@ -1,5 +1,5 @@
 dateOp;dateVal;label;category;categoryParent;amount;accountNum;accountLabel;accountbalance
-2019-03-12;2019-03-12;"Prime Parrainage";"Virements reçus";"Virements reçus";80,00;001234;"BOURSORAMA BANQUE";370,00
-2019-03-12;2019-03-12;"VIR VIREMENT CREATION COMPTE";"Virements reçus";"Virements reçus";300,00;001234;"BOURSORAMA BANQUE";370,00
-2019-03-12;2019-03-12;"VIR VIREMENT CREATION COMPTE";"Virements émis de comptes à comptes";"Mouvements internes débiteurs";-10,00;001234;"BOURSORAMA BANQUE";370,00
-2019-03-12;2019-03-12;"VIR VIREMENT CREATION COMPTE";"Virements reçus de comptes à comptes";"Mouvements internes créditeurs";10,00;003607;"COMPTE SUR LIVRET";"4 810,00"
+2019-03-12;2019-03-12;"Prime Parrainage";"Virements reï¿½us";"Virements reï¿½us";80,00;001234;"BOURSORAMA BANQUE";370.00
+2019-03-12;2019-03-12;"VIR VIREMENT CREATION COMPTE";"Virements reï¿½us";"Virements reï¿½us";300,00;001234;"BOURSORAMA BANQUE";370.00
+2019-03-12;2019-03-12;"VIR VIREMENT CREATION COMPTE";"Virements ï¿½mis de comptes ï¿½ comptes";"Mouvements internes dï¿½biteurs";-10,00;001234;"BOURSORAMA BANQUE";370.00
+2019-03-12;2019-03-12;"VIR VIREMENT CREATION COMPTE";"Virements reï¿½us de comptes ï¿½ comptes";"Mouvements internes crï¿½diteurs";10,00;003607;"COMPTE SUR LIVRET";4810.00

--- a/test/test_boursorama.py
+++ b/test/test_boursorama.py
@@ -50,8 +50,8 @@ Date,Amount
     new_file.write_text(
         """\
 dateOp;dateVal;Label;category;categoryParent;Amount;accountNum;accountLabel;accountbalance
-2019-08-30;2019-08-30;"VIR Virement interne depuis BOURSORA";"Virements reçus de comptes à comptes";"Mouvements internes créditeurs";10,00;00001234;"COMPTE SUR LIVRET";"1 000,00"
-2019-09-02;2019-09-02;"VIR Virement interne depuis BOURSORA";"Virements reçus de comptes à comptes";"Mouvements internes créditeurs";11,00;00001234;"COMPTE SUR LIVRET";"1 000,00"
+2019-08-30;2019-08-30;"VIR Virement interne depuis BOURSORA";"Virements reçus de comptes à comptes";"Mouvements internes créditeurs";10,00;00001234;"COMPTE SUR LIVRET";1000.00
+2019-09-02;2019-09-02;"VIR Virement interne depuis BOURSORA";"Virements reçus de comptes à comptes";"Mouvements internes créditeurs";11,00;00001234;"COMPTE SUR LIVRET";1000.00
 """,  # noqa: E501
         encoding="ISO-8859-1",
     )
@@ -99,7 +99,7 @@ Date,Amount,Currency
     assert balance_file in summary.targets
 
 
-def test_boursorama_account_read_raw(cfg):
+def test_boursorama_account_read_raw_2019_03_30(cfg):
     csv = cfg.download_dir / "export-operations-30-03-2019_08-50-51.csv"
 
     account = BoursoramaAccount("type1", "name1", "001234")
@@ -118,39 +118,74 @@ def test_boursorama_account_read_raw(cfg):
             "Date",
             "Label",
             "Amount",
-            "accountNum",
-            "accountLabel",
-            "accountBalance",
             "Currency",
+            "accountNum",
         ],
         data=[
             (
                 pd.Timestamp("2019-03-12"),
                 "Prime Parrainage",
                 80.0,
-                "001234",
-                "BOURSORAMA BANQUE",
-                370.0,
                 "EUR",
+                "001234",
             ),
             (
                 pd.Timestamp("2019-03-12"),
                 "VIR VIREMENT CREATION COMPTE",
                 300.0,
-                "001234",
-                "BOURSORAMA BANQUE",
-                370.0,
                 "EUR",
+                "001234",
             ),
             (
                 pd.Timestamp("2019-03-12"),
                 "VIR VIREMENT CREATION COMPTE",
                 -10.0,
-                "001234",
-                "BOURSORAMA BANQUE",
-                370.0,
                 "EUR",
+                "001234",
             ),
+        ],
+    )
+    assert_frame_equal(expected_transactions, actual_transactions)
+
+
+def test_boursorama_account_read_raw_2022_06_11(cfg):
+    csv = cfg.download_dir / "export-operations-11-06-2022_09-52-55.csv"
+
+    account = BoursoramaAccount("type1", "name1", "001234")
+    cfg.accounts.append(account)
+    actual_balances, actual_transactions = BoursoramaTransactionPipeline(
+        account, cfg
+    ).read_raw(csv)
+
+    expected_balances = pd.DataFrame(
+        columns=["accountNum", "Date", "Amount", "Currency"],
+        data=[
+            (
+                "001234",
+                # -1 because of https://github.com/mincong-h/finance-toolkit/issues/72
+                pd.Timestamp("2022-06-10"),
+                226.68,
+                "EUR",
+            )
+        ],
+    )
+    assert_frame_equal(expected_balances, actual_balances)
+    expected_transactions = pd.DataFrame(
+        columns=[
+            "Date",
+            "Label",
+            "Amount",
+            "Currency",
+            "accountNum",
+        ],
+        data=[
+            (
+                pd.Timestamp("2021-08-17"),
+                "Prime Parrainage",
+                130.0,
+                "EUR",
+                "001234",
+            )
         ],
     )
     assert_frame_equal(expected_transactions, actual_transactions)
@@ -187,10 +222,8 @@ def test_boursorama_account_read_raw_account_2(cfg):
             "Date": pd.Timestamp("2019-03-12"),
             "Label": "VIR VIREMENT CREATION COMPTE",
             "Amount": 10.0,
-            "accountNum": "003607",
-            "accountLabel": "COMPTE SUR LIVRET",
-            "accountBalance": 4810.0,
             "Currency": "EUR",
+            "accountNum": "003607",
         },
         index=[0],
     )

--- a/test/test_boursorama.py
+++ b/test/test_boursorama.py
@@ -127,7 +127,7 @@ dateOp;dateVal;label;category;categoryParent;amount;comment;accountNum;accountLa
 Failed to read new Boursorama data. Details:
   path={csv}
   headers=dateOp;dateVal;label;category;categoryParent;amount;comment;accountNum;accountLabel;accountbalance
-  pandas_kwargs={{'decimal': ',', 'delimiter': ';', 'dtype': {{'accountNum': 'str'}}, 'encoding': 'ISO-8859-1', 'parse_dates': ['dateOp', 'dateVal'], 'skipinitialspace': True, 'thousands': ' '}}
+  pandas_kwargs={{'decimal': ',', 'delimiter': ';', 'dtype': {{'accountNum': 'str', 'accountbalance': 'str'}}, 'encoding': 'ISO-8859-1', 'parse_dates': ['dateOp', 'dateVal'], 'skipinitialspace': True, 'thousands': ' '}}
   pandas_error=oops"""  # noqa: E501
     )
 

--- a/test/test_boursorama.py
+++ b/test/test_boursorama.py
@@ -55,7 +55,6 @@ dateOp;dateVal;Label;category;categoryParent;Amount;accountNum;accountLabel;acco
 2019-08-30;2019-08-30;"VIR Virement interne depuis BOURSORA";"Virements reçus de comptes à comptes";"Mouvements internes créditeurs";10,00;00001234;"COMPTE SUR LIVRET";1000.00
 2019-09-02;2019-09-02;"VIR Virement interne depuis BOURSORA";"Virements reçus de comptes à comptes";"Mouvements internes créditeurs";11,00;00001234;"COMPTE SUR LIVRET";1000.00
 """,  # noqa: E501
-        encoding="ISO-8859-1",
     )
 
     # When integrating new lines
@@ -127,7 +126,7 @@ dateOp;dateVal;label;category;categoryParent;amount;comment;accountNum;accountLa
 Failed to read new Boursorama data. Details:
   path={csv}
   headers=dateOp;dateVal;label;category;categoryParent;amount;comment;accountNum;accountLabel;accountbalance
-  pandas_kwargs={{'decimal': ',', 'delimiter': ';', 'dtype': {{'accountNum': 'str', 'accountbalance': 'str'}}, 'encoding': 'ISO-8859-1', 'parse_dates': ['dateOp', 'dateVal'], 'skipinitialspace': True, 'thousands': ' '}}
+  pandas_kwargs={{'decimal': ',', 'delimiter': ';', 'dtype': {{'accountNum': 'str', 'accountbalance': 'str'}}, 'encoding': 'UTF-8', 'parse_dates': ['dateOp', 'dateVal'], 'skipinitialspace': True, 'thousands': ' '}}
   pandas_error=oops"""  # noqa: E501
     )
 


### PR DESCRIPTION
## Account Balance

**TL;DR: format(amount)=FR, format(accountbalance)=ISO** 

Previously, the format of the column "accountbalance" was written in French format:

* "1 000,00"
* 370,00

Now it is using the ISO format without thousands separator:

* 1000.00
* 370.00

but the other column "amount" remains unchanged -- i.e. still in French format. To fix this, we consider the column "accountbalance" as string when reading the CSV file and cast it ourselves.

## Encoding

Previously the encoding of the file is ISO-8859-1, it had been changed to UTF-8 now. When using ISO-8859-1, we can see the problem from this error, where `dateOp` was considered as `ï»¿dateOp`:

```
finance_toolkit.pipeline.PipelineDataError: Failed to read new Boursorama data. Details:
  path=/data/source/export-operations-11-06-2022_09-52-55.csv
  headers=ï»¿dateOp;dateVal;label;category;categoryParent;amount;comment;accountNum;accountLabel;accountbalance
  pandas_kwargs={'decimal': ',', 'delimiter': ';', 'dtype': {'accountNum': 'str'}, 'encoding': 'ISO-8859-1', 'parse_dates': ['dateOp', 'dateVal'], 'skipinitialspace': True, 'thousands': ' '}
  pandas_error=Missing column provided to 'parse_dates': 'dateOp'
```