### PR TITLE
Improve error handling for Boursorama

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,8 @@
+codecov:
+  status:
+    project:
+      default:
+        threshold: 100%  # allow dropping 100%, i.e. always success
+    patch:
+      default:
+        threshold: 100%  # allow dropping 100%, i.e. always success

--- a/finance_toolkit/boursorama.py
+++ b/finance_toolkit/boursorama.py
@@ -1,4 +1,3 @@
-import logging
 from abc import ABCMeta
 from datetime import datetime
 from pathlib import Path
@@ -68,11 +67,11 @@ class BoursoramaPipeline(Pipeline, metaclass=ABCMeta):
         except ValueError as e:
             raise PipelineDataError(
                 msg="Failed to read new Boursorama data.",
-                cause=e,
+                path=csv,
                 expected_columns=self.raw_data_columns_dtype,
                 type_columns=dtype,
                 date_columns=parse_dates,
-                path=csv,
+                pandas_cause=e,
             )
 
         df = df.rename(columns={"accountbalance": "accountBalance"})

--- a/finance_toolkit/boursorama.py
+++ b/finance_toolkit/boursorama.py
@@ -54,7 +54,7 @@ class BoursoramaPipeline(Pipeline, metaclass=ABCMeta):
         try:
             df = pd.read_csv(csv, **kwargs)
         except ValueError as e:
-            with csv.open(encoding="ISO-8859-1") as f:
+            with csv.open(encoding=kwargs["encoding"]) as f:
                 headers = next(f).strip()
             raise PipelineDataError(
                 msg="Failed to read new Boursorama data.",

--- a/finance_toolkit/boursorama.py
+++ b/finance_toolkit/boursorama.py
@@ -65,13 +65,14 @@ class BoursoramaPipeline(Pipeline, metaclass=ABCMeta):
                 thousands=" ",
             )
         except ValueError as e:
+            # TODO add first line of the CSV
             raise PipelineDataError(
                 msg="Failed to read new Boursorama data.",
                 path=csv,
                 expected_columns=self.raw_data_columns_dtype,
-                type_columns=dtype,
-                date_columns=parse_dates,
-                pandas_cause=e,
+                pandas_dtype=dtype,
+                pandas_parse_dates=parse_dates,
+                pandas_error=e,
             )
 
         df = df.rename(columns={"accountbalance": "accountBalance"})

--- a/finance_toolkit/boursorama.py
+++ b/finance_toolkit/boursorama.py
@@ -54,10 +54,12 @@ class BoursoramaPipeline(Pipeline, metaclass=ABCMeta):
         try:
             df = pd.read_csv(csv, **kwargs)
         except ValueError as e:
-            # TODO add first line of the CSV
+            with csv.open(encoding="ISO-8859-1") as f:
+                headers = next(f).strip()
             raise PipelineDataError(
                 msg="Failed to read new Boursorama data.",
                 path=csv,
+                headers=headers,
                 pandas_kwargs=kwargs,
                 pandas_error=e,
             )

--- a/finance_toolkit/boursorama.py
+++ b/finance_toolkit/boursorama.py
@@ -37,7 +37,7 @@ class BoursoramaAccount(Account):
 
 
 class BoursoramaPipeline(Pipeline, metaclass=ABCMeta):
-    raw_data_columns_dtype={
+    raw_data_columns_dtype = {
         "dateOp": "date",
         "dateVal": "date",
         "label": "?",
@@ -51,8 +51,14 @@ class BoursoramaPipeline(Pipeline, metaclass=ABCMeta):
         self.account: BoursoramaAccount = account
 
     def read_raw(self, csv: Path) -> Tuple[DataFrame, DataFrame]:
-        dtype = {col: t for col, t in self.raw_data_columns_dtype.items() if t not in ["?", "date"]}
-        parse_dates = [col for col, t in self.raw_data_columns_dtype.items() if t == "date"]
+        dtype = {
+            col: t
+            for col, t in self.raw_data_columns_dtype.items()
+            if t not in ["?", "date"]
+        }
+        parse_dates = [
+            col for col, t in self.raw_data_columns_dtype.items() if t == "date"
+        ]
         try:
             df = pd.read_csv(
                 csv,

--- a/finance_toolkit/pipeline.py
+++ b/finance_toolkit/pipeline.py
@@ -187,13 +187,15 @@ class AccountParser:
 
 
 class PipelineDataError(ValueError):
-    def __init__(self,
-                 msg: str,
-                 path: Path,
-                 expected_columns: Dict[str, str],
-                 pandas_dtype: Dict[str, str],
-                 pandas_parse_dates: List[str],
-                 pandas_error: ValueError):
+    def __init__(
+        self,
+        msg: str,
+        path: Path,
+        expected_columns: Dict[str, str],
+        pandas_dtype: Dict[str, str],
+        pandas_parse_dates: List[str],
+        pandas_error: ValueError,
+    ):
         self.msg = msg
         self.path = path
         self.expected_columns = expected_columns

--- a/finance_toolkit/pipeline.py
+++ b/finance_toolkit/pipeline.py
@@ -191,23 +191,17 @@ class PipelineDataError(ValueError):
         self,
         msg: str,
         path: Path,
-        expected_columns: Dict[str, str],
-        pandas_dtype: Dict[str, str],
-        pandas_parse_dates: List[str],
         pandas_error: ValueError,
+        pandas_kwargs,
     ):
         self.msg = msg
         self.path = path
-        self.expected_columns = expected_columns
-        self.pandas_dtype = pandas_dtype
-        self.pandas_parse_dates = pandas_parse_dates
+        self.pandas_kwargs = pandas_kwargs
         self.pandas_error = pandas_error
 
     def __str__(self):
         return f"""\
 {self.msg} Details:
   path={self.path}
-  expected_columns={self.expected_columns}
-  pandas_dtype={self.pandas_dtype}
-  pandas_parse_dates={self.pandas_parse_dates}
+  pandas_kwargs={self.pandas_kwargs}
   pandas_error={self.pandas_error}"""

--- a/finance_toolkit/pipeline.py
+++ b/finance_toolkit/pipeline.py
@@ -191,21 +191,21 @@ class PipelineDataError(ValueError):
                  msg: str,
                  path: Path,
                  expected_columns: Dict[str, str],
-                 type_columns: Dict[str, str],
-                 date_columns: List[str],
-                 pandas_cause: ValueError):
+                 pandas_dtype: Dict[str, str],
+                 pandas_parse_dates: List[str],
+                 pandas_error: ValueError):
         self.msg = msg
         self.path = path
         self.expected_columns = expected_columns
-        self.type_columns = type_columns
-        self.date_columns = date_columns
-        self.pandas_cause = pandas_cause
+        self.pandas_dtype = pandas_dtype
+        self.pandas_parse_dates = pandas_parse_dates
+        self.pandas_error = pandas_error
 
     def __str__(self):
         return f"""\
 {self.msg} Details:
   path={self.path}
   expected_columns={self.expected_columns}
-  type_columns={self.type_columns}
-  date_columns={self.date_columns}
-  pandas_cause={self.pandas_cause}"""
+  pandas_dtype={self.pandas_dtype}
+  pandas_parse_dates={self.pandas_parse_dates}
+  pandas_error={self.pandas_error}"""

--- a/finance_toolkit/pipeline.py
+++ b/finance_toolkit/pipeline.py
@@ -1,6 +1,7 @@
 import logging
 from abc import ABCMeta, abstractmethod
 from pathlib import Path
+from typing import Dict
 
 import pandas as pd
 from pandas import DataFrame
@@ -183,3 +184,18 @@ class AccountParser:
             account_num="unknown",
             patterns=[r"unknown"],
         )
+
+
+class PipelineDataError(ValueError):
+    def __init__(self, msg: str, path: Path, expected_columns: Dict[str, str], cause: ValueError):
+        self.msg = msg
+        self.path = path
+        self.expected_columns = expected_columns
+        self.cause = cause
+
+    def __repr__(self):
+        return f"""\
+{self.msg} Details:
+  path={self.path}
+  expected_columns={self.expected_columns}
+  cause={self.cause}"""

--- a/finance_toolkit/pipeline.py
+++ b/finance_toolkit/pipeline.py
@@ -193,7 +193,7 @@ class PipelineDataError(ValueError):
         self.expected_columns = expected_columns
         self.cause = cause
 
-    def __repr__(self):
+    def __str__(self):
         return f"""\
 {self.msg} Details:
   path={self.path}

--- a/finance_toolkit/pipeline.py
+++ b/finance_toolkit/pipeline.py
@@ -193,13 +193,13 @@ class PipelineDataError(ValueError):
                  expected_columns: Dict[str, str],
                  type_columns: Dict[str, str],
                  date_columns: List[str],
-                 cause: ValueError):
+                 pandas_cause: ValueError):
         self.msg = msg
         self.path = path
         self.expected_columns = expected_columns
         self.type_columns = type_columns
         self.date_columns = date_columns
-        self.cause = cause
+        self.pandas_cause = pandas_cause
 
     def __str__(self):
         return f"""\
@@ -208,4 +208,4 @@ class PipelineDataError(ValueError):
   expected_columns={self.expected_columns}
   type_columns={self.type_columns}
   date_columns={self.date_columns}
-  cause={self.cause}"""
+  pandas_cause={self.pandas_cause}"""

--- a/finance_toolkit/pipeline.py
+++ b/finance_toolkit/pipeline.py
@@ -1,7 +1,7 @@
 import logging
 from abc import ABCMeta, abstractmethod
 from pathlib import Path
-from typing import Dict
+from typing import Dict, List
 
 import pandas as pd
 from pandas import DataFrame
@@ -187,10 +187,18 @@ class AccountParser:
 
 
 class PipelineDataError(ValueError):
-    def __init__(self, msg: str, path: Path, expected_columns: Dict[str, str], cause: ValueError):
+    def __init__(self,
+                 msg: str,
+                 path: Path,
+                 expected_columns: Dict[str, str],
+                 type_columns: Dict[str, str],
+                 date_columns: List[str],
+                 cause: ValueError):
         self.msg = msg
         self.path = path
         self.expected_columns = expected_columns
+        self.type_columns = type_columns
+        self.date_columns = date_columns
         self.cause = cause
 
     def __str__(self):
@@ -198,4 +206,6 @@ class PipelineDataError(ValueError):
 {self.msg} Details:
   path={self.path}
   expected_columns={self.expected_columns}
+  type_columns={self.type_columns}
+  date_columns={self.date_columns}
   cause={self.cause}"""

--- a/finance_toolkit/pipeline.py
+++ b/finance_toolkit/pipeline.py
@@ -1,7 +1,6 @@
 import logging
 from abc import ABCMeta, abstractmethod
 from pathlib import Path
-from typing import Dict, List
 
 import pandas as pd
 from pandas import DataFrame
@@ -191,11 +190,13 @@ class PipelineDataError(ValueError):
         self,
         msg: str,
         path: Path,
+        headers: str,
         pandas_error: ValueError,
         pandas_kwargs,
     ):
         self.msg = msg
         self.path = path
+        self.headers = headers
         self.pandas_kwargs = pandas_kwargs
         self.pandas_error = pandas_error
 
@@ -203,5 +204,6 @@ class PipelineDataError(ValueError):
         return f"""\
 {self.msg} Details:
   path={self.path}
+  headers={self.headers}
   pandas_kwargs={self.pandas_kwargs}
   pandas_error={self.pandas_error}"""

--- a/test/test_boursorama.py
+++ b/test/test_boursorama.py
@@ -1,6 +1,7 @@
 import re
 from pathlib import Path
 from tempfile import TemporaryDirectory
+from unittest.mock import patch
 
 import pandas as pd
 import pytest
@@ -12,6 +13,7 @@ from finance_toolkit.boursorama import (
     BoursoramaTransactionPipeline,
 )
 from finance_toolkit.models import Summary, TxType
+from finance_toolkit.pipeline import PipelineDataError
 from finance_toolkit.tx import TxCompletion
 
 
@@ -97,6 +99,37 @@ Date,Amount,Currency
     assert tx08 in summary.targets
     assert tx09 in summary.targets
     assert balance_file in summary.targets
+
+
+@patch("pandas.read_csv")
+def test_pipeline_read_raw(mocked_read_csv, cfg):
+    mocked_read_csv.side_effect = ValueError("oops")
+    csv = cfg.root_dir / "export-operations-11-06-2022_18-00-00.csv"
+    csv.write_text(
+        """\
+dateOp;dateVal;label;category;categoryParent;amount;comment;accountNum;accountLabel;accountbalance
+2021-08-17;2021-08-17;"Prime Parrainage";"Virements reçus";"Virements reçus";130,00;;00040677485;"BOURSORAMA BANQUE";226.68
+"""  # noqa: E501
+    )
+
+    account = BoursoramaAccount("type1", "name1", "001234")
+    cfg.accounts.append(account)
+    captured_error = None
+
+    try:
+        BoursoramaTransactionPipeline(account, cfg).read_raw(csv)
+    except PipelineDataError as e:
+        captured_error = e
+
+    assert (
+        str(captured_error)
+        == f"""\
+Failed to read new Boursorama data. Details:
+  path={csv}
+  headers=dateOp;dateVal;label;category;categoryParent;amount;comment;accountNum;accountLabel;accountbalance
+  pandas_kwargs={{'decimal': ',', 'delimiter': ';', 'dtype': {{'accountNum': 'str'}}, 'encoding': 'ISO-8859-1', 'parse_dates': ['dateOp', 'dateVal'], 'skipinitialspace': True, 'thousands': ' '}}
+  pandas_error=oops"""  # noqa: E501
+    )
 
 
 def test_boursorama_account_read_raw(cfg):


### PR DESCRIPTION
When an error occurs, the exception contains more information for debugging, where we have the path of the CSV file, the expected columns and their types, and all the pandas-specific fields. Here is an example:

```
Traceback (most recent call last):
  File "/usr/local/bin/finance-toolkit", line 33, in <module>
    sys.exit(load_entry_point('finance-toolkit==0.1.0', 'console_scripts', 'finance-toolkit')())
  File "/usr/local/lib/python3.7/site-packages/finance_toolkit-0.1.0-py3.7.egg/finance_toolkit/__main__.py", line 71, in main
  File "/usr/local/lib/python3.7/site-packages/finance_toolkit-0.1.0-py3.7.egg/finance_toolkit/tx.py", line 237, in move
  File "/usr/local/lib/python3.7/site-packages/finance_toolkit-0.1.0-py3.7.egg/finance_toolkit/pipeline.py", line 30, in run
  File "/usr/local/lib/python3.7/site-packages/finance_toolkit-0.1.0-py3.7.egg/finance_toolkit/boursorama.py", line 115, in read_new_transactions
  File "/usr/local/lib/python3.7/site-packages/finance_toolkit-0.1.0-py3.7.egg/finance_toolkit/boursorama.py", line 64, in read_raw
finance_toolkit.pipeline.PipelineDataError: Failed to read new Boursorama data. Details:
  path=/data/source/export-operations-11-06-2022_09-52-55.csv
  headers=ï»¿dateOp;dateVal;label;category;categoryParent;amount;comment;accountNum;accountLabel;accountbalance
  pandas_kwargs={'decimal': ',', 'delimiter': ';', 'dtype': {'accountNum': 'str'}, 'encoding': 'ISO-8859-1', 'parse_dates': ['dateOp', 'dateVal'], 'skipinitialspace': True, 'thousands': ' '}
  pandas_error=Missing column provided to 'parse_dates': 'dateOp'
```

Thanks for this custom error, we know that we cannot trust pandas' error as we already provided "dateOp" to the "parse_dates".