### PR TITLE
codecov: switch to informational mode

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -3,7 +3,7 @@ codecov:
   status:
     project:
       default:
-        threshold: 100%  # allow dropping 100%, i.e. always success
+        informational: true
     patch:
       default:
-        threshold: 100%  # allow dropping 100%, i.e. always success
+        informational: true


### PR DESCRIPTION
Use Codecov in informational mode. Default is false. If true is specified the
resulting status will pass no matter what the coverage is or what other
settings are specified. Informational mode is great to use if you want to
expose codecov information to other developers in your pull request without
necessarily gating PRs on that information.