### PR TITLE
Allow specifying extra patterns for Revolut

### DIFF
--- a/finance-tools.sample.yml
+++ b/finance-tools.sample.yml
@@ -57,8 +57,6 @@ accounts:
     type: CHQ
     id: 'astark1'
     currency: EUR
-    expressions:
-      - account-statement_(\d{4}-\d{2}-\d{2})_(\d{4}-\d{2}-\d{2})_en_(\w+)\.csv
     label: Arya Stark - Revolut (Euro)
 
   astark-REV-USD:
@@ -66,6 +64,8 @@ accounts:
     type: CHQ
     id: 'astark2'
     currency: USD
+    expressions:
+      - account-statement_(\d{4}-\d{2}-\d{2})_(\d{4}-\d{2}-\d{2})_en_(\w+)\.csv
     label: Arya Stark - Revolut (US Dollar)
 
 # Categories

--- a/finance-tools.sample.yml
+++ b/finance-tools.sample.yml
@@ -57,6 +57,8 @@ accounts:
     type: CHQ
     id: 'astark1'
     currency: EUR
+    expressions:
+      - account-statement_(\d{4}-\d{2}-\d{2})_(\d{4}-\d{2}-\d{2})_en_(\w+)\.csv
     label: Arya Stark - Revolut (Euro)
 
   astark-REV-USD:

--- a/finance_toolkit/revolut.py
+++ b/finance_toolkit/revolut.py
@@ -1,6 +1,6 @@
 from abc import ABCMeta
 from pathlib import Path
-from typing import Tuple
+from typing import Tuple, List
 
 import pandas as pd
 from pandas import DataFrame
@@ -12,18 +12,26 @@ from .pipeline import Pipeline, TransactionPipeline, BalancePipeline
 
 class RevolutAccount(Account):
     def __init__(
-        self, account_type: str, account_id: str, account_num: str, currency: str
+        self,
+        account_type: str,
+        account_id: str,
+        account_num: str,
+        currency: str,
+        extra_patterns: List[str] = None,
     ):
+        patterns = [
+            r"Revolut-(.*)-Statement-(.*)\.csv",
+            r"account-statement_(\d{4}-\d{2}-\d{2})_(\d{4}-\d{2}-\d{2})_undefined-undefined_%s\.csv"  # noqa
+            % account_num,
+        ]
+        if extra_patterns:
+            patterns.extend(extra_patterns)
         super().__init__(
             account_type=account_type,
             account_id=account_id,
             account_num=account_num,
             currency=currency,
-            patterns=[
-                r"Revolut-(.*)-Statement-(.*)\.csv",
-                r"account-statement_(\d{4}-\d{2}-\d{2})_(\d{4}-\d{2}-\d{2})_undefined-undefined_%s\.csv"  # noqa
-                % account_num,
-            ],
+            patterns=patterns,
         )
 
 

--- a/finance_toolkit/tx.py
+++ b/finance_toolkit/tx.py
@@ -90,7 +90,7 @@ class Configurator:
                         account_id=symbolic_name,
                         account_num=fields["id"],
                         currency=fields["currency"],
-                        extra_patterns=fields["expressions"],
+                        extra_patterns=fields["expressions"] if "expressions" in fields else None,
                     )
                 )
             elif company == "October":

--- a/finance_toolkit/tx.py
+++ b/finance_toolkit/tx.py
@@ -90,6 +90,7 @@ class Configurator:
                         account_id=symbolic_name,
                         account_num=fields["id"],
                         currency=fields["currency"],
+                        extra_patterns=fields["expressions"],
                     )
                 )
             elif company == "October":

--- a/test/test_tx.py
+++ b/test/test_tx.py
@@ -637,6 +637,9 @@ def test_configurator_parse_yaml(sample):
             account_id="astark-REV-EUR",
             account_num="astark1",
             currency="EUR",
+            extra_patterns=[
+                r"account-statement_(\d{4}-\d{2}-\d{2})_(\d{4}-\d{2}-\d{2})_en_(\w+)\.csv"
+            ],
         ),
         RevolutAccount(
             account_type="CHQ",

--- a/test/test_tx.py
+++ b/test/test_tx.py
@@ -637,15 +637,15 @@ def test_configurator_parse_yaml(sample):
             account_id="astark-REV-EUR",
             account_num="astark1",
             currency="EUR",
-            extra_patterns=[
-                r"account-statement_(\d{4}-\d{2}-\d{2})_(\d{4}-\d{2}-\d{2})_en_(\w+)\.csv"
-            ],
         ),
         RevolutAccount(
             account_type="CHQ",
             account_id="astark-REV-USD",
             account_num="astark2",
             currency="USD",
+            extra_patterns=[
+                r"account-statement_(\d{4}-\d{2}-\d{2})_(\d{4}-\d{2}-\d{2})_en_(\w+)\.csv"
+            ],
         ),
         BnpAccount(
             account_type="LVA",


### PR DESCRIPTION
because I realized that the existing patterns weren't defined correctly. This will still happen in the future, which may cause by: bugs, renaming from the bank, ... So it makes sense to allow specifying extra patterns by user without needing the modify the source code.