### PR TITLE
Refactor the file detection for Revolut

### DIFF
--- a/bin/docker-finance.sh
+++ b/bin/docker-finance.sh
@@ -1,10 +1,29 @@
 #!/bin/bash
-
+#
+# Wrapper script to run Finance Toolkit in Docker
+#
+# Arguments (environment variables):
+#
+#   FTK_DOCKER_MODE:
+#       Optional. The Docker mode to be used: "remote" or "local". Default value
+#       is "remote", meaning that the Docker image will be pulled from the
+#       remote registry. "LOCAL" means using the Docker image built locally,
+#       useful for testing.
+#
 REGISTRY_NAME="registry-intl.cn-hongkong.aliyuncs.com"
 IMAGE_NAMESPACE="jimidata-prod"
 image="${REGISTRY_NAME}/${IMAGE_NAMESPACE}/finance-toolkit:latest"
 
-docker pull "$image"
+docker_mode=${FTK_DOCKER_MODE:-remote}
+
+echo "FTK_DOCKER_MODE: ${FTK_DOCKER_MODE}"
+echo "---"
+
+if [ "$docker_mode" == "remote" ]
+then
+  docker pull "$image"
+fi
+
 docker run \
     --rm \
     --volume "${HOME}/Downloads:/data/source" \

--- a/finance_toolkit/pipeline_factory.py
+++ b/finance_toolkit/pipeline_factory.py
@@ -33,6 +33,8 @@ class PipelineFactory:
         if isinstance(account, FortuneoAccount):
             return FortuneoTransactionPipeline(account, self.cfg)
         if isinstance(account, RevolutAccount):
+            if account.skip_integration:
+                return NoopTransactionPipeline(account, self.cfg)
             return RevolutTransactionPipeline(account, self.cfg)
         return NoopTransactionPipeline(account, self.cfg)
 
@@ -42,6 +44,8 @@ class PipelineFactory:
         if isinstance(account, BoursoramaAccount):
             return BoursoramaBalancePipeline(account, self.cfg)
         if isinstance(account, RevolutAccount):
+            if account.skip_integration:
+                return GeneralBalancePipeline(account, self.cfg)
             return RevolutBalancePipeline(account, self.cfg)
         return GeneralBalancePipeline(account, self.cfg)
 

--- a/finance_toolkit/revolut.py
+++ b/finance_toolkit/revolut.py
@@ -56,6 +56,7 @@ class RevolutAccount(Account):
             currency=currency,
             patterns=patterns,
         )
+        self.skip_integration = account_type != self.TYPE_CASH
 
 
 class RevolutPipeline(Pipeline, metaclass=ABCMeta):

--- a/finance_toolkit/revolut.py
+++ b/finance_toolkit/revolut.py
@@ -57,13 +57,16 @@ class RevolutAccount(Account):
 
 
 class RevolutPipeline(Pipeline, metaclass=ABCMeta):
-    @classmethod
-    def read_raw(cls, csv: Path) -> Tuple[DataFrame, DataFrame]:
+    def read_raw(self, csv: Path) -> Tuple[DataFrame, DataFrame]:
         df = pd.read_csv(
             csv,
             delimiter=",",
             parse_dates=["Started Date", "Completed Date"],
         )
+
+        # In Revolut, the downloaded CSV files do not contain sufficient information about the
+        # account. Therefore, we iterate through all files and post-filter on the currency-symbol.
+        df = df.loc[df["Currency"] == self.account.currency_symbol]
 
         balances = df[["Completed Date", "Balance", "Currency"]]
         balances = balances.rename(

--- a/finance_toolkit/revolut.py
+++ b/finance_toolkit/revolut.py
@@ -19,10 +19,7 @@ class RevolutAccount(Account):
     # A commodities account is an investment account for commodities, such as gold.
     TYPE_COMMODITIES = "commodities"
 
-    default_patterns = {
-        "EUR": r"account-statement_(\d{4}-\d{2}-\d{2})_(\d{4}-\d{2}-\d{2})_undefined-undefined_(\w+)\.csv",  # noqa
-        "USD": r"account-statement_(\d{4}-\d{2}-\d{2})_(\d{4}-\d{2}-\d{2})_en_(\w+)\.csv",  # noqa
-    }
+    default_pattern = r"account-statement_(\d{4}-\d{2}-\d{2})_(\d{4}-\d{2}-\d{2})_undefined-undefined_(\w+)\.csv"  # noqa
 
     def __init__(
         self,
@@ -45,7 +42,7 @@ class RevolutAccount(Account):
         """
         patterns = [
             r"Revolut-(.*)-Statement-(.*)\.csv",
-            self.default_patterns[currency],
+            self.default_pattern,
         ]
         if extra_patterns:
             patterns.extend(extra_patterns)

--- a/finance_toolkit/revolut.py
+++ b/finance_toolkit/revolut.py
@@ -11,6 +11,14 @@ from .pipeline import Pipeline, TransactionPipeline, BalancePipeline
 
 
 class RevolutAccount(Account):
+    # Account type "cash"
+    # A cash account contains cash in one single currency.
+    TYPE_CASH = "cash"
+
+    # Account type "commodities"
+    # A commodities account is an investment account for commodities, such as gold.
+    TYPE_COMMODITIES = "commodities"
+
     default_patterns = {
         "EUR": r"account-statement_(\d{4}-\d{2}-\d{2})_(\d{4}-\d{2}-\d{2})_undefined-undefined_(\w+)\.csv",  # noqa
         "USD": r"account-statement_(\d{4}-\d{2}-\d{2})_(\d{4}-\d{2}-\d{2})_en_(\w+)\.csv",  # noqa
@@ -24,6 +32,17 @@ class RevolutAccount(Account):
         currency: str,
         extra_patterns: List[str] = None,
     ):
+        """
+        Initialize a new account for Revolut.
+
+        :param account_type: the type of the account, known types are listed as class variables
+            "TYPE_*".
+        :param account_id: the internal identifier of the account used by Finance Toolkit
+        :param account_num: the external identifier of the account used by Revolut
+        :param currency: the currency used by this account.
+        :param extra_patterns: the additional regular expression patterns used for CSV-file lookup
+            on top of the default ones.
+        """
         patterns = [
             r"Revolut-(.*)-Statement-(.*)\.csv",
             self.default_patterns[currency],

--- a/test/test_account.py
+++ b/test/test_account.py
@@ -240,21 +240,17 @@ def test_revolut_account_match_dollar():
         account_type="aType", account_id="anId", account_num="myLogin", currency="USD"
     )
     assert account.match(Path("Revolut-EUR-Statement-Oct – Nov 2020.csv"))
+    assert account.match(
+        Path("account-statement_2021-01-01_2022-05-27_undefined-undefined_abc123.csv")
+    )
+    assert account.match(
+        Path("account-statement_2021-01-01_2022-05-27_undefined-undefined_edf123.csv")
+    )
     assert (
-        account.match(
-            Path(
-                "account-statement_2021-01-01_2022-05-27_undefined-undefined_abc123.csv"
-            )
-        )
+        account.match(Path("account-statement_2021-01-01_2022-05-27_en_abc123.csv"))
         is False
     )
     assert (
-        account.match(
-            Path(
-                "account-statement_2021-01-01_2022-05-27_undefined-undefined_edf123.csv"
-            )
-        )
+        account.match(Path("account-statement_2021-01-01_2022-05-27_en_edf123.csv"))
         is False
     )
-    assert account.match(Path("account-statement_2021-01-01_2022-05-27_en_abc123.csv"))
-    assert account.match(Path("account-statement_2021-01-01_2022-05-27_en_edf123.csv"))

--- a/test/test_pipeline.py
+++ b/test/test_pipeline.py
@@ -12,9 +12,11 @@ from finance_toolkit.boursorama import (
     BoursoramaTransactionPipeline,
 )
 from finance_toolkit.fortuneo import FortuneoAccount, FortuneoTransactionPipeline
-from finance_toolkit.pipeline import (
-    GeneralBalancePipeline,
-    NoopTransactionPipeline,
+from finance_toolkit.pipeline import GeneralBalancePipeline, NoopTransactionPipeline
+from finance_toolkit.revolut import (
+    RevolutAccount,
+    RevolutTransactionPipeline,
+    RevolutBalancePipeline,
 )
 from finance_toolkit.pipeline_factory import PipelineFactory
 
@@ -41,11 +43,38 @@ def test_new_transaction_pipeline(cfg):
             patterns=["unknown"],
         )
     )
+    p_r1 = PipelineFactory(cfg).new_transaction_pipeline(
+        RevolutAccount(
+            account_type=RevolutAccount.TYPE_CASH,
+            account_id="foo-REV-USD",
+            account_num="unknown",
+            currency="USD",
+        )
+    )
+    p_r2 = PipelineFactory(cfg).new_transaction_pipeline(
+        RevolutAccount(
+            account_type=RevolutAccount.TYPE_CASH,
+            account_id="foo-REV-EUR",
+            account_num="unknown",
+            currency="USD",
+        )
+    )
+    p_r3 = PipelineFactory(cfg).new_transaction_pipeline(
+        RevolutAccount(
+            account_type=RevolutAccount.TYPE_COMMODITIES,
+            account_id="foo-REV-GLD",
+            account_num="unknown",
+            currency="USD",
+        )
+    )
 
     assert isinstance(p1, BnpTransactionPipeline)
     assert isinstance(p2, BoursoramaTransactionPipeline)
     assert isinstance(p3, FortuneoTransactionPipeline)
     assert isinstance(p4, NoopTransactionPipeline)
+    assert isinstance(p_r1, RevolutTransactionPipeline)
+    assert isinstance(p_r2, RevolutTransactionPipeline)
+    assert isinstance(p_r3, NoopTransactionPipeline)
 
 
 def test_new_balance_pipeline(cfg):
@@ -64,7 +93,34 @@ def test_new_balance_pipeline(cfg):
             patterns=["unknown"],
         )
     )
+    p_r1 = PipelineFactory(cfg).new_balance_pipeline(
+        RevolutAccount(
+            account_type=RevolutAccount.TYPE_CASH,
+            account_id="foo-REV-USD",
+            account_num="unknown",
+            currency="USD",
+        )
+    )
+    p_r2 = PipelineFactory(cfg).new_balance_pipeline(
+        RevolutAccount(
+            account_type=RevolutAccount.TYPE_CASH,
+            account_id="foo-REV-EUR",
+            account_num="unknown",
+            currency="USD",
+        )
+    )
+    p_r3 = PipelineFactory(cfg).new_balance_pipeline(
+        RevolutAccount(
+            account_type=RevolutAccount.TYPE_COMMODITIES,
+            account_id="foo-REV-GLD",
+            account_num="unknown",
+            currency="USD",
+        )
+    )
 
     assert isinstance(p1, BnpBalancePipeline)
     assert isinstance(p2, BoursoramaBalancePipeline)
     assert isinstance(p3, GeneralBalancePipeline)
+    assert isinstance(p_r1, RevolutBalancePipeline)
+    assert isinstance(p_r2, RevolutBalancePipeline)
+    assert isinstance(p_r3, GeneralBalancePipeline)

--- a/test/test_revolut.py
+++ b/test/test_revolut.py
@@ -4,7 +4,6 @@ from pandas.testing import assert_frame_equal
 from finance_toolkit.models import Summary
 from finance_toolkit.revolut import (
     RevolutAccount,
-    RevolutPipeline,
     RevolutBalancePipeline,
     RevolutTransactionPipeline,
 )
@@ -16,9 +15,17 @@ def test_read_raw_2022_05_27(cfg):
         cfg.download_dir
         / "account-statement_2021-01-01_2022-05-27_undefined-undefined_abc123.csv"
     )
+    account = RevolutAccount(
+        account_type="EUR",
+        account_id="user-REV-EUR",
+        account_num="abc123",
+        currency="EUR",
+    )
 
     # When
-    actual_balances, actual_transactions = RevolutPipeline.read_raw(csv)
+    actual_balances, actual_transactions = RevolutTransactionPipeline(
+        account, cfg
+    ).read_raw(csv)
 
     # Then
     expected_balances = pd.DataFrame(

--- a/test/test_revolut.py
+++ b/test/test_revolut.py
@@ -9,7 +9,7 @@ from finance_toolkit.revolut import (
 )
 
 
-def test_read_raw_2022_05_27(cfg):
+def test_read_raw_2022_05_27_euro(cfg):
     # Given
     csv = (
         cfg.download_dir
@@ -66,6 +66,40 @@ def test_read_raw_2022_05_27(cfg):
         ],
     )
     assert_frame_equal(actual_transactions, expected_transactions)
+
+
+def test_read_raw_2022_05_27_dollar(cfg):
+    # Given
+    csv = (
+        cfg.download_dir
+        / "account-statement_2021-01-01_2022-05-27_undefined-undefined_abc123.csv"
+    )
+    account = RevolutAccount(
+        account_type=RevolutAccount.TYPE_CASH,
+        account_id="user-REV-USD",
+        account_num="abc123",
+        currency="USD",
+    )
+
+    # When
+    actual_balances, actual_transactions = RevolutTransactionPipeline(
+        account, cfg
+    ).read_raw(csv)
+
+    # Then both data-frames are empty
+    assert actual_balances.columns.values.tolist() == ["Date", "Amount", "Currency"]
+    assert len(actual_balances) == 0
+
+    assert actual_transactions.columns.values.tolist() == [
+        "Date",
+        "Label",
+        "Amount",
+        "Currency",
+        "Type",
+        "MainCategory",
+        "SubCategory",
+    ]
+    assert len(actual_transactions.columns)
 
 
 def test_integration_normal(cfg):


### PR DESCRIPTION
This PR fixes https://github.com/mincong-h/finance-toolkit/issues/85 . More precisely,

- [x] It introduces new account types that users must follow when using Revolut.
- [x] It avoids relying on the filenames for detecting accounts because they change sometimes ("en" vs "undefined_undefined"), which is not reliable. Instead, it uses a post-filtering mechanism on field "currency" to matching account.
- [x] It changes the loading logic based on the account type (only take care "cash" accounts as "commodities" accounts' statements cannot be downloaded).