### PR TITLE
Support exchange rate for balances

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,5 @@
+{
+    "python.testing.pytestArgs": [],
+    "python.testing.unittestEnabled": false,
+    "python.testing.pytestEnabled": true
+}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## 1.4.0
+
+* Support currency conversion based on exchange rates provided by the Bank of
+  France.
+
 ## 1.3.0
 
 * Upgrade to Python 3.10

--- a/docs/exchange-rate.md
+++ b/docs/exchange-rate.md
@@ -1,0 +1,7 @@
+# Exchange Rate
+
+The exchange rate information is downloaded from the Bank of France. The file format is
+
+    Webstat_Export_{YYYYMMDD}.csv
+
+where `YYYY` is the year in 4 digits, the `MM` is the month in 2 digits, and `DD` is the day of month in 2 digits.

--- a/docs/exchange-rate.md
+++ b/docs/exchange-rate.md
@@ -2,6 +2,27 @@
 
 The exchange rate information is downloaded from the Bank of France. The file format is
 
-    Webstat_Export_{YYYYMMDD}.csv
+```
+Webstat_Export_{YYYYMMDD}.csv
+```
 
-where `YYYY` is the year in 4 digits, the `MM` is the month in 2 digits, and `DD` is the day of the month in 2 digits.
+where `YYYY` is the year in 4 digits, the `MM` is the month in 2 digits, and `DD` is the day of the month in 2 digits. Finance Toolkit performs cleanup for the data internally and the final results are stored in CSV in the following structure:
+
+```
+Date,USD,CNY
+2024-01-05,1.0921,7.813
+2024-01-04,1.0953,7.833
+2024-01-03,1.0919,7.8057
+2024-01-02,1.0956,7.8264
+2024-01-01,,
+2023-12-31,,
+2023-12-30,,
+2023-12-29,1.105,7.8509
+2023-12-28,1.1114,7.8941
+```
+
+where:
+
+* The "Date" column is the date of the exchange rates. Note that the accuracy stops at the date level, we don't have precision on finer levels (hours, minutes, seconds).
+* Other columns represent the exchange rate between the base currency Euro and the target currency `$CODE`, for example, the U.S. Dollar (USD) and the Chinese Yuan (CNY).
+* If the exchange rate is missing on some dates, we use the forward-filling technique, meaning that we take the latest valid value for the current date.

--- a/docs/exchange-rate.md
+++ b/docs/exchange-rate.md
@@ -4,4 +4,4 @@ The exchange rate information is downloaded from the Bank of France. The file fo
 
     Webstat_Export_{YYYYMMDD}.csv
 
-where `YYYY` is the year in 4 digits, the `MM` is the month in 2 digits, and `DD` is the day of month in 2 digits.
+where `YYYY` is the year in 4 digits, the `MM` is the month in 2 digits, and `DD` is the day of the month in 2 digits.

--- a/finance-tools.sample.yml
+++ b/finance-tools.sample.yml
@@ -121,8 +121,8 @@ download-dir: ~/Downloads
 # Exchange Rates
 # ------------------
 # Configuration related to the exchange rates.
-exchange_rate:
+exchange-rate:
   # Currencies used by your bank accounts or other accounts.
-  watched_currencies:
+  watched-currencies:
     - USD
     - CNY

--- a/finance-tools.sample.yml
+++ b/finance-tools.sample.yml
@@ -117,3 +117,12 @@ auto-complete:
 #   - macOS: ~/Downloads
 #
 download-dir: ~/Downloads
+
+# Exchange Rates
+# ------------------
+# Configuration related to the exchange rates.
+exchange_rate:
+  # Currencies used by your bank accounts or other accounts.
+  watched_currencies:
+    - USD
+    - CNY

--- a/finance_toolkit/__init__.py
+++ b/finance_toolkit/__init__.py
@@ -1,9 +1,9 @@
 """Finance Tools"""
 
-__version__ = "0.1.0"
+__version__ = "1.3.0"
 __author__ = "The Finance Toolkit Team"
 __copyright__ = """
-Copyright (c) 2019-2020, The Finance Toolkit Team
+Copyright (c) 2019-2024, The Finance Toolkit Team
 
 Permission to use, copy, modify, and distribute this software and its
 documentation for any purpose and without fee or royalty is hereby

--- a/finance_toolkit/account.py
+++ b/finance_toolkit/account.py
@@ -36,6 +36,7 @@ class Account:
         self.num: str = account_num
         self.currency_symbol: str = currency
         self.filename: str = f"{account_id}.csv"
+        self.euro_filename: str = f"{account_id}.EUR.csv"
 
     def __hash__(self):
         return hash(
@@ -45,6 +46,7 @@ class Account:
                 self.num,
                 self.currency_symbol,
                 self.filename,
+                self.euro_filename,
             )
         )
 
@@ -57,6 +59,7 @@ class Account:
             and self.num == o.num
             and self.currency_symbol == o.currency_symbol
             and self.filename == o.filename
+            and self.euro_filename == o.euro_filename
         )
 
     def __repr__(self) -> str:

--- a/finance_toolkit/account.py
+++ b/finance_toolkit/account.py
@@ -36,7 +36,6 @@ class Account:
         self.num: str = account_num
         self.currency_symbol: str = currency
         self.filename: str = f"{account_id}.csv"
-        self.euro_filename: str = f"{account_id}.EUR.csv"
 
     def __hash__(self):
         return hash(
@@ -46,7 +45,6 @@ class Account:
                 self.num,
                 self.currency_symbol,
                 self.filename,
-                self.euro_filename,
             )
         )
 
@@ -59,7 +57,6 @@ class Account:
             and self.num == o.num
             and self.currency_symbol == o.currency_symbol
             and self.filename == o.filename
-            and self.euro_filename == o.euro_filename
         )
 
     def __repr__(self) -> str:
@@ -87,6 +84,16 @@ class Account:
             else:
                 logging.debug(f"{p.pattern}: not matched")
         return False
+
+    def get_balance_filename(self) -> str:
+        return f"balance.{self.id}.csv"
+
+    def get_euro_balance_filename(self) -> str:
+        """
+        Returns the filename of the balance in Euro, which is used for standardizing accounts
+        because user may hold their assets in multiple currencies, e.g. EUR, USD, GBP, etc.
+        """
+        return f"balance.{self.id}.EUR.csv"
 
 
 class DegiroAccount(Account):

--- a/finance_toolkit/account.py
+++ b/finance_toolkit/account.py
@@ -63,7 +63,10 @@ class Account:
         return (
             f"{type(self).__name__}<type={self.type!r}, "
             f"id={self.id!r}, num={self.altered_num!r}, "
-            f"currency_symbol={self.currency_symbol!r}>"
+            f"currency_symbol={self.currency_symbol!r}, "
+            f"balance_filename={self.balance_filename!r}, "
+            f"converted_balance_filename={self.converted_balance_filename!r}"
+            f">"
         )
 
     @property
@@ -85,15 +88,25 @@ class Account:
                 logging.debug(f"{p.pattern}: not matched")
         return False
 
-    def get_balance_filename(self) -> str:
-        return f"balance.{self.id}.csv"
+    @property
+    def balance_filename(self) -> str:
+        return f"balance.{self.id}.{self.currency_symbol}.csv"
 
-    def get_euro_balance_filename(self) -> str:
+    @property
+    def converted_balance_filename(self) -> str:
         """
-        Returns the filename of the balance in Euro, which is used for standardizing accounts
-        because user may hold their assets in multiple currencies, e.g. EUR, USD, GBP, etc.
+        Returns the filename of the balance in Euro, which is used as the base currency for
+        standardizing accounts. We need this because user may hold their assets in multiple
+        currencies, e.g. EUR, USD, GBP, etc.
         """
         return f"balance.{self.id}.EUR.csv"
+
+    @property
+    def is_currency_conversion_needed(self) -> bool:
+        """
+        Returns True if the account needs currency conversion.
+        """
+        return self.currency_symbol != "EUR"
 
 
 class DegiroAccount(Account):

--- a/finance_toolkit/exchange_rate.py
+++ b/finance_toolkit/exchange_rate.py
@@ -1,0 +1,49 @@
+import logging
+from abc import ABCMeta
+import datetime
+from pathlib import Path
+import pandas as pd
+import re
+
+from .pipeline import Pipeline
+from .models import Summary
+
+
+class ExchangeRatePipeline(Pipeline, metaclass=ABCMeta):
+    """
+    Pipeline to download exchange rates from the Bank of France and save them to a CSV file.
+    """
+    def run(self, csv: Path, summary: Summary) -> None:
+        logging.debug(f"Running {self.__class__.__name__} on {csv}")
+        with csv.open() as f:
+            # The 6 first lines of the CSV file are special. For example:
+            #
+            #     Titre :;Dollar australien (AUD);Lev bulgare (BGN);Real brésilien (BRL)
+            #     Code série :;EXR.D.AUD.EUR.SP00.A;EXR.D.BGN.EUR.SP00.A;EXR.D.BRL.EUR.SP00.A
+            #     Unité :;Dollar Australien (AUD);Lev Nouveau (BGN);Real Bresilien (BRL)
+            #     Magnitude :;Unités (0);Unités (0);Unités (0)
+            #     Méthode d'observation :;Fin de période (E);Fin de période (E);Fin de période (E)
+            #     Source :;BCE (Banque Centrale Européenne) (4F0);BCE (Banque Centrale Européenne) (4F0);BCE (Banque Centrale Européenne) (4F0)
+            #
+            next(f)  # title (Titre)
+            next(f)  # series code (Code série)
+            unit_str = next(f)  # units (Unité)
+            logging.debug(unit_str)
+
+        rates = pd.read_csv(
+            csv,
+            date_parser=lambda s: datetime.strptime(s, "%d/%m/%Y"),
+            decimal=",",
+            delimiter=";",
+            skiprows=6,  # Titre, Code série, Unité, Magnitude, Méthode d'observation, Source
+            names=[self.extract_code(u) for u in unit_str.split(";")]
+        )
+        rates = rates[['Dates', 'USD', 'CNY']]
+        logging.debug(f"Head of {csv}\n{rates.head()}")
+
+    def extract_code(self, s: str) -> str:
+        match = re.search(r'\((\w+)\)', s)
+        if match:
+            return match.group(1)
+        else:
+            return 'Dates'

--- a/finance_toolkit/exchange_rate.py
+++ b/finance_toolkit/exchange_rate.py
@@ -1,6 +1,6 @@
 import logging
 from abc import ABCMeta
-import datetime
+from datetime import datetime
 from pathlib import Path
 import pandas as pd
 import re
@@ -36,6 +36,7 @@ class ExchangeRatePipeline(Pipeline, metaclass=ABCMeta):
         rate_df = pd.read_csv(
             csv,
             date_parser=lambda s: datetime.strptime(s, "%d/%m/%Y"),
+            parse_dates=['Date'],
             decimal=",",
             delimiter=";",
             na_values="-",
@@ -43,11 +44,11 @@ class ExchangeRatePipeline(Pipeline, metaclass=ABCMeta):
             names=[self.extract_code(u) for u in unit_str.split(";")]
         )
         rate_df = rate_df[['Date', 'USD', 'CNY']]  # TODO(mincong): make it configurable
-        logging.debug(f"Head of {csv}\n{rate_df.head()}")
 
         target = self.cfg.get_exchange_rate_csv_path()
         logging.debug(f"Saving exchange rates to {target}")
-        rate_df.to_csv(target, index=False, date_format="%Y-%m-%d")  #, float_format="%.4f")
+        logging.debug(rate_df.head())
+        rate_df.to_csv(target, index=False, date_format="%Y-%m-%d")
 
     def extract_code(self, s: str) -> str:
         match = re.search(r'\((\w+)\)', s)

--- a/finance_toolkit/exchange_rate.py
+++ b/finance_toolkit/exchange_rate.py
@@ -43,7 +43,7 @@ class ExchangeRatePipeline(Pipeline, metaclass=ABCMeta):
             skiprows=6,  # Titre, Code série, Unité, Magnitude, Méthode d'observation, Source
             names=[self.extract_code(u) for u in unit_str.split(";")]
         )
-        rate_df = rate_df[['Date', 'USD', 'CNY']]  # TODO(mincong): make it configurable
+        rate_df = rate_df[['Date'] + self.cfg.exchange_rate_currencies]
         rate_df = rate_df.sort_values(by=['Date'], ascending=True)
 
         target = self.cfg.get_exchange_rate_csv_path()

--- a/finance_toolkit/exchange_rate.py
+++ b/finance_toolkit/exchange_rate.py
@@ -44,6 +44,7 @@ class ExchangeRatePipeline(Pipeline, metaclass=ABCMeta):
             names=[self.extract_code(u) for u in unit_str.split(";")]
         )
         rate_df = rate_df[['Date', 'USD', 'CNY']]  # TODO(mincong): make it configurable
+        rate_df = rate_df.sort_values(by=['Date'], ascending=True)
 
         target = self.cfg.get_exchange_rate_csv_path()
         logging.debug(f"Saving exchange rates to {target}")

--- a/finance_toolkit/exchange_rate.py
+++ b/finance_toolkit/exchange_rate.py
@@ -20,7 +20,7 @@ class ExchangeRatePipeline(Pipeline, metaclass=ABCMeta):
         Unité :;Dollar Australien (AUD);Lev Nouveau (BGN);Real Bresilien (BRL)
         Magnitude :;Unités (0);Unités (0);Unités (0)
         Méthode d'observation :;Fin de période (E);Fin de période (E);Fin de période (E)
-        Source :;BCE (Banque Centrale Européenne) (4F0);BCE (Banque Centrale Européenne) (4F0);BCE (Banque Centrale Européenne) (4F0)
+        Source :;BCE (Banque Centrale Européenne) (4F0);BCE (Banque Centrale Européenne) (4F0);...
 
     This has an impact on the way we read the CSV file.
     """

--- a/finance_toolkit/exchange_rate.py
+++ b/finance_toolkit/exchange_rate.py
@@ -12,34 +12,42 @@ from .models import Summary
 class ExchangeRatePipeline(Pipeline, metaclass=ABCMeta):
     """
     Pipeline to download exchange rates from the Bank of France and save them to a CSV file.
+
+    The 6 first lines of the CSV file are special. For example:
+
+        Titre :;Dollar australien (AUD);Lev bulgare (BGN);Real brésilien (BRL)
+        Code série :;EXR.D.AUD.EUR.SP00.A;EXR.D.BGN.EUR.SP00.A;EXR.D.BRL.EUR.SP00.A
+        Unité :;Dollar Australien (AUD);Lev Nouveau (BGN);Real Bresilien (BRL)
+        Magnitude :;Unités (0);Unités (0);Unités (0)
+        Méthode d'observation :;Fin de période (E);Fin de période (E);Fin de période (E)
+        Source :;BCE (Banque Centrale Européenne) (4F0);BCE (Banque Centrale Européenne) (4F0);BCE (Banque Centrale Européenne) (4F0)
+
+    This has an impact on the way we read the CSV file.
     """
     def run(self, csv: Path, summary: Summary) -> None:
         logging.debug(f"Running {self.__class__.__name__} on {csv}")
         with csv.open() as f:
-            # The 6 first lines of the CSV file are special. For example:
-            #
-            #     Titre :;Dollar australien (AUD);Lev bulgare (BGN);Real brésilien (BRL)
-            #     Code série :;EXR.D.AUD.EUR.SP00.A;EXR.D.BGN.EUR.SP00.A;EXR.D.BRL.EUR.SP00.A
-            #     Unité :;Dollar Australien (AUD);Lev Nouveau (BGN);Real Bresilien (BRL)
-            #     Magnitude :;Unités (0);Unités (0);Unités (0)
-            #     Méthode d'observation :;Fin de période (E);Fin de période (E);Fin de période (E)
-            #     Source :;BCE (Banque Centrale Européenne) (4F0);BCE (Banque Centrale Européenne) (4F0);BCE (Banque Centrale Européenne) (4F0)
             #
             next(f)  # title (Titre)
             next(f)  # series code (Code série)
             unit_str = next(f)  # units (Unité)
             logging.debug(unit_str)
 
-        rates = pd.read_csv(
+        rate_df = pd.read_csv(
             csv,
             date_parser=lambda s: datetime.strptime(s, "%d/%m/%Y"),
             decimal=",",
             delimiter=";",
+            na_values="-",
             skiprows=6,  # Titre, Code série, Unité, Magnitude, Méthode d'observation, Source
             names=[self.extract_code(u) for u in unit_str.split(";")]
         )
-        rates = rates[['Dates', 'USD', 'CNY']]
-        logging.debug(f"Head of {csv}\n{rates.head()}")
+        rate_df = rate_df[['Dates', 'USD', 'CNY']]  # TODO(mincong): make it configurable
+        logging.debug(f"Head of {csv}\n{rate_df.head()}")
+
+        target = self.cfg.root_dir / "exchange-rate.csv"
+        logging.debug(f"Saving exchange rates to {target}")
+        rate_df.to_csv(target, index=False, date_format="%Y-%m-%d", float_format="%.4f")
 
     def extract_code(self, s: str) -> str:
         match = re.search(r'\((\w+)\)', s)

--- a/finance_toolkit/exchange_rate.py
+++ b/finance_toolkit/exchange_rate.py
@@ -42,16 +42,16 @@ class ExchangeRatePipeline(Pipeline, metaclass=ABCMeta):
             skiprows=6,  # Titre, Code série, Unité, Magnitude, Méthode d'observation, Source
             names=[self.extract_code(u) for u in unit_str.split(";")]
         )
-        rate_df = rate_df[['Dates', 'USD', 'CNY']]  # TODO(mincong): make it configurable
+        rate_df = rate_df[['Date', 'USD', 'CNY']]  # TODO(mincong): make it configurable
         logging.debug(f"Head of {csv}\n{rate_df.head()}")
 
-        target = self.cfg.root_dir / "exchange-rate.csv"
+        target = self.cfg.get_exchange_rate_csv_path()
         logging.debug(f"Saving exchange rates to {target}")
-        rate_df.to_csv(target, index=False, date_format="%Y-%m-%d", float_format="%.4f")
+        rate_df.to_csv(target, index=False, date_format="%Y-%m-%d")  #, float_format="%.4f")
 
     def extract_code(self, s: str) -> str:
         match = re.search(r'\((\w+)\)', s)
         if match:
             return match.group(1)
         else:
-            return 'Dates'
+            return 'Date'

--- a/finance_toolkit/models.py
+++ b/finance_toolkit/models.py
@@ -79,9 +79,12 @@ class TxCompletion:
 
 @dataclass
 class ExchangeRateConfig:
-    base_currency: str
     watched_currencies: List[str]
 
+    @property
+    def base_currency(self) -> str:
+        # note: the base currency is not configurable, it can only be euro for now
+        return "EUR"
 
 class Configuration:
     """

--- a/finance_toolkit/models.py
+++ b/finance_toolkit/models.py
@@ -77,6 +77,12 @@ class TxCompletion:
         )
 
 
+@dataclass
+class ExchangeRateConfig:
+    base_currency: str = "EUR"
+    watched_currencies: List[str]
+
+
 class Configuration:
     """
     Type-safe representation of the user configuration.
@@ -90,6 +96,7 @@ class Configuration:
         autocomplete: List[TxCompletion],
         download_dir: Path,
         root_dir: Path,
+        exchange_rate_cfg: ExchangeRateConfig,
     ):
         self.accounts: List[Account] = accounts
         self.category_set: Set[str] = set(categories)
@@ -97,6 +104,7 @@ class Configuration:
         self.autocomplete: List[TxCompletion] = autocomplete
         self.download_dir: Path = download_dir
         self.root_dir: Path = root_dir
+        self.exchange_rate_cfg: ExchangeRateConfig = exchange_rate_cfg
 
     def as_dict(self) -> Dict[str, Account]:
         return {a.id: a for a in self.accounts}
@@ -112,6 +120,10 @@ class Configuration:
 
     def get_exchange_rate_csv_path(self) -> Path:
         return self.root_dir / "exchange-rate.csv"
+
+    @property
+    def exchange_rate_currencies(self) -> List[str]:
+        return self.exchange_rate_cfg.watched_currencies
 
 
 class Summary:

--- a/finance_toolkit/models.py
+++ b/finance_toolkit/models.py
@@ -79,7 +79,7 @@ class TxCompletion:
 
 @dataclass
 class ExchangeRateConfig:
-    base_currency: str = "EUR"
+    base_currency: str
     watched_currencies: List[str]
 
 

--- a/finance_toolkit/models.py
+++ b/finance_toolkit/models.py
@@ -110,6 +110,9 @@ class Configuration:
         """
         return sorted(c for c in filter(cat_filter, self.category_set))
 
+    def get_exchange_rate_csv_path(self) -> Path:
+        return self.root_dir / "exchange-rate.csv"
+
 
 class Summary:
     def __init__(self, cfg: Configuration):

--- a/finance_toolkit/models.py
+++ b/finance_toolkit/models.py
@@ -86,6 +86,7 @@ class ExchangeRateConfig:
         # note: the base currency is not configurable, it can only be euro for now
         return "EUR"
 
+
 class Configuration:
     """
     Type-safe representation of the user configuration.

--- a/finance_toolkit/pipeline.py
+++ b/finance_toolkit/pipeline.py
@@ -172,6 +172,7 @@ class BalancePipeline(Pipeline, metaclass=ABCMeta):
 
         df = df.drop_duplicates(subset=["Date"], keep="last")
         df = df.sort_values(by="Date")
+        df = df.reset_index(drop=True)
         return df
 
     def write_balance(self, csv: Path, df: DataFrame) -> DataFrame:

--- a/finance_toolkit/pipeline.py
+++ b/finance_toolkit/pipeline.py
@@ -178,6 +178,14 @@ class GeneralBalancePipeline(BalancePipeline):
         pass
 
 
+class ExchangeRatePipeline(Pipeline, metaclass=ABCMeta):
+    """
+    Pipeline to download exchange rates from the Bank of France and save them to a CSV file.
+    """
+    def run(self, path: Path, summary: Summary) -> None:
+        print(f"Downloading exchange rates to {path}")
+
+
 class AccountParser:
     def __init__(self, cfg: Configuration):
         self.accounts = cfg.as_dict()

--- a/finance_toolkit/pipeline.py
+++ b/finance_toolkit/pipeline.py
@@ -183,10 +183,11 @@ class BalancePipeline(Pipeline, metaclass=ABCMeta):
         balance_df["Date"] = balance_df["Date"].dt.date  # remove time before the join
 
         exchange_rate_df = pd.read_csv(self.cfg.get_exchange_rate_csv_path(), parse_dates=["Date"])
-        exchange_rate_df = exchange_rate_df.fillna(method="ffill")  # forward fill: propagate last valid observation forward to next valid
+        # forward fill: propagate last valid observation forward to next valid
+        exchange_rate_df = exchange_rate_df.fillna(method="ffill")
         exchange_rate_df["EUR"] = 1.0
 
-        logging.debug(f"Converting the balance of account {self.account.id} from {self.account.currency_symbol} to EUR")
+        logging.debug(f"Converting the balance of account {self.account.id} from {self.account.currency_symbol} to EUR")  # noqa
         result_df = pd.merge(balance_df, exchange_rate_df,
                              left_on="Date",
                              right_on=exchange_rate_df["Date"].dt.date,

--- a/finance_toolkit/pipeline.py
+++ b/finance_toolkit/pipeline.py
@@ -178,14 +178,6 @@ class GeneralBalancePipeline(BalancePipeline):
         pass
 
 
-class ExchangeRatePipeline(Pipeline, metaclass=ABCMeta):
-    """
-    Pipeline to download exchange rates from the Bank of France and save them to a CSV file.
-    """
-    def run(self, path: Path, summary: Summary) -> None:
-        print(f"Downloading exchange rates to {path}")
-
-
 class AccountParser:
     def __init__(self, cfg: Configuration):
         self.accounts = cfg.as_dict()

--- a/finance_toolkit/pipeline_factory.py
+++ b/finance_toolkit/pipeline_factory.py
@@ -16,6 +16,7 @@ from .pipeline import (
     NoopTransactionPipeline,
     BalancePipeline,
     GeneralBalancePipeline,
+    ExchangeRatePipeline,
     AccountParser,
 )
 from .revolut import RevolutAccount, RevolutTransactionPipeline, RevolutBalancePipeline
@@ -48,6 +49,9 @@ class PipelineFactory:
                 return GeneralBalancePipeline(account, self.cfg)
             return RevolutBalancePipeline(account, self.cfg)
         return GeneralBalancePipeline(account, self.cfg)
+
+    def new_exchange_rate_pipeline(self) -> ExchangeRatePipeline:
+        return ExchangeRatePipeline(None, self.cfg)
 
     def parse_balance_pipeline(self, path: Path) -> BalancePipeline:
         account = AccountParser(self.cfg).parse(path)

--- a/finance_toolkit/pipeline_factory.py
+++ b/finance_toolkit/pipeline_factory.py
@@ -16,9 +16,9 @@ from .pipeline import (
     NoopTransactionPipeline,
     BalancePipeline,
     GeneralBalancePipeline,
-    ExchangeRatePipeline,
     AccountParser,
 )
+from .exchange_rate import ExchangeRatePipeline
 from .revolut import RevolutAccount, RevolutTransactionPipeline, RevolutBalancePipeline
 
 

--- a/finance_toolkit/tx.py
+++ b/finance_toolkit/tx.py
@@ -15,7 +15,7 @@ from .account import (
 from .bnp import BnpAccount
 from .boursorama import BoursoramaAccount
 from .fortuneo import FortuneoAccount
-from .models import Configuration, Summary, TxCompletion, TxType
+from .models import Configuration, Summary, TxCompletion, TxType, ExchangeRateConfig
 from .pipeline import AccountParser
 from .pipeline_factory import PipelineFactory
 from .revolut import RevolutAccount
@@ -130,6 +130,10 @@ class Configurator:
         return [] if raw is None else [TxCompletion.load(p) for p in raw]
 
     @classmethod
+    def load_exchange_rates(cls, raw: Dict) -> ExchangeRateConfig:
+        return ExchangeRateConfig(watched_currencies=raw["watched_currencies"])
+
+    @classmethod
     def parse_yaml(cls, path: Path) -> Configuration:
         data = yaml.safe_load(path.read_text())
         accounts = cls.load_accounts(data["accounts"])
@@ -145,6 +149,7 @@ class Configurator:
             autocomplete=autocomplete,
             download_dir=download_dir,
             root_dir=root_dir,
+            exchange_rate_cfg=cls.load_exchange_rates(data["exchange-rate"]),
         )
 
     @classmethod

--- a/finance_toolkit/tx.py
+++ b/finance_toolkit/tx.py
@@ -131,7 +131,7 @@ class Configurator:
 
     @classmethod
     def load_exchange_rates(cls, raw: Dict) -> ExchangeRateConfig:
-        return ExchangeRateConfig(watched_currencies=raw["watched_currencies"])
+        return ExchangeRateConfig(watched_currencies=raw["watched-currencies"])
 
     @classmethod
     def parse_yaml(cls, path: Path) -> Configuration:

--- a/finance_toolkit/tx.py
+++ b/finance_toolkit/tx.py
@@ -131,7 +131,8 @@ class Configurator:
 
     @classmethod
     def load_exchange_rates(cls, raw: Dict) -> ExchangeRateConfig:
-        return ExchangeRateConfig(watched_currencies=raw["watched_currencies"])
+        # note: the base currency is not configurable, it can only be euro for now
+        return ExchangeRateConfig(base_currency="EUR", watched_currencies=raw["watched_currencies"])
 
     @classmethod
     def parse_yaml(cls, path: Path) -> Configuration:
@@ -142,6 +143,7 @@ class Configurator:
         autocomplete = cls.load_autocomplete(data["auto-complete"])
         download_dir = Path(data["download-dir"]).expanduser()
         root_dir = path.parent
+        exchange_rate_cfg = cls.load_exchange_rates(data["exchange-rate"])
         return Configuration(
             accounts=accounts,
             categories=categories,
@@ -149,7 +151,7 @@ class Configurator:
             autocomplete=autocomplete,
             download_dir=download_dir,
             root_dir=root_dir,
-            exchange_rate_cfg=cls.load_exchange_rates(data["exchange-rate"]),
+            exchange_rate_cfg=exchange_rate_cfg,
         )
 
     @classmethod

--- a/finance_toolkit/tx.py
+++ b/finance_toolkit/tx.py
@@ -239,6 +239,8 @@ def move(cfg: Configuration):
             if account.match(path):
                 factory.new_transaction_pipeline(account).run(path, summary)
                 factory.new_balance_pipeline(account).run(path, summary)
+        if path.name == "Webstat_Export_20240107.csv":
+            factory.new_exchange_rate_pipeline().run(path, summary)
     print(summary)
 
 

--- a/finance_toolkit/tx.py
+++ b/finance_toolkit/tx.py
@@ -131,8 +131,7 @@ class Configurator:
 
     @classmethod
     def load_exchange_rates(cls, raw: Dict) -> ExchangeRateConfig:
-        # note: the base currency is not configurable, it can only be euro for now
-        return ExchangeRateConfig(base_currency="EUR", watched_currencies=raw["watched_currencies"])
+        return ExchangeRateConfig(watched_currencies=raw["watched_currencies"])
 
     @classmethod
     def parse_yaml(cls, path: Path) -> Configuration:

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -5,6 +5,7 @@ from tempfile import TemporaryDirectory
 import pytest
 
 from finance_toolkit.tx import Configuration
+from finance_toolkit.models import ExchangeRateConfig
 
 
 @pytest.fixture(scope="session")
@@ -42,6 +43,7 @@ def cfg(tmpdir, location):
         autocomplete=[],
         download_dir=source_dir,
         root_dir=target_dir,
+        exchange_rate_cfg=ExchangeRateConfig(watched_currencies=["USD", "CNY"])
     )
 
 

--- a/test/test_account.py
+++ b/test/test_account.py
@@ -38,18 +38,20 @@ def test_account_repr_attrs():
         account_type="aType",
         account_id="anId",
         account_num="00000001",
-        currency="EUR",
+        currency="USD",
         patterns=[r".*"],
     )
     assert (
         repr(a)
-        == "Account<type='aType', id='anId', num='****0001', currency_symbol='EUR'>"
+        == "Account<type='aType', id='anId', num='****0001', currency_symbol='USD', balance_filename='balance.anId.USD.csv', converted_balance_filename='balance.anId.EUR.csv'>"
     )
     assert a.type == "aType"
     assert a.id == "anId"
     assert a.num == "00000001"
     assert a.altered_num == "****0001"
-    assert a.currency_symbol == "EUR"
+    assert a.currency_symbol == "USD"
+    assert a.balance_filename == "balance.anId.USD.csv"
+    assert a.converted_balance_filename == "balance.anId.EUR.csv"
 
 
 # ---------- Class: BnpAccount ----------

--- a/test/test_account.py
+++ b/test/test_account.py
@@ -43,7 +43,7 @@ def test_account_repr_attrs():
     )
     assert (
         repr(a)
-        == "Account<type='aType', id='anId', num='****0001', currency_symbol='USD', balance_filename='balance.anId.USD.csv', converted_balance_filename='balance.anId.EUR.csv'>"
+        == "Account<type='aType', id='anId', num='****0001', currency_symbol='USD', balance_filename='balance.anId.USD.csv', converted_balance_filename='balance.anId.EUR.csv'>"  # noqa: E501
     )
     assert a.type == "aType"
     assert a.id == "anId"

--- a/test/test_bnp.py
+++ b/test/test_bnp.py
@@ -36,7 +36,7 @@ Date,Label,Amount,Type,MainCategory,SubCategory
     )
 
     # And a file for balance
-    b = cfg.root_dir / "balance.xxx.csv"
+    b = cfg.root_dir / "balance.xxx.EUR.csv"
     with b.open("w") as f:
         f.write("mainCategory,subCategory,accountNum,Date,Amount\n")
         f.write("main,sub,****1234,2018-08-02,24.37\n")

--- a/test/test_bnp.py
+++ b/test/test_bnp.py
@@ -80,7 +80,7 @@ Date,Label,Amount,Currency,Type,MainCategory,SubCategory
     assert b in summary.targets
 
 
-def test_bnp_balance_pipeline_write_balances(cfg):
+def test_bnp_balance_pipeline_insert_balance(cfg):
     # Given an existing CSV file with 2 rows
     csv = cfg.root_dir / "balance.xxx.csv"
     csv.write_text(
@@ -100,18 +100,18 @@ Date,Amount
         }
     )
     account = BnpAccount("CHQ", "xxx", "****1234")
-    BnpBalancePipeline(account, cfg).write_balances(csv, new_lines)
+    new_df = BnpBalancePipeline(account, cfg).insert_balance(csv, new_lines)
 
     # Then rows are available and sorted
-    assert (
-        csv.read_text()
-        == """\
-Date,Amount,Currency
-2018-07-04,189.29,EUR
-2018-08-02,724.37,EUR
-2018-09-02,924.37,EUR
-"""
+    expected_df = pd.DataFrame(
+        columns=["Date", "Amount", "Currency"],
+        data=[
+            (pd.Timestamp("2018-07-04"), 189.29, "EUR"),
+            (pd.Timestamp("2018-08-02"), 724.37, "EUR"),
+            (pd.Timestamp("2018-09-02"), 924.37, "EUR"),
+        ],
     )
+    assert_frame_equal(new_df, expected_df)
 
 
 def test_bnp_pipeline_read_raw_20190703(cfg):

--- a/test/test_bnp.py
+++ b/test/test_bnp.py
@@ -100,7 +100,7 @@ Date,Amount
         }
     )
     account = BnpAccount("CHQ", "xxx", "****1234")
-    new_df = BnpBalancePipeline(account, cfg).insert_balance(csv, new_lines)
+    actual_df = BnpBalancePipeline(account, cfg).insert_balance(csv, new_lines)
 
     # Then rows are available and sorted
     expected_df = pd.DataFrame(
@@ -111,7 +111,7 @@ Date,Amount
             (pd.Timestamp("2018-09-02"), 924.37, "EUR"),
         ],
     )
-    assert_frame_equal(new_df, expected_df)
+    assert_frame_equal(actual_df, expected_df)
 
 
 def test_bnp_pipeline_read_raw_20190703(cfg):

--- a/test/test_boursorama.py
+++ b/test/test_boursorama.py
@@ -38,12 +38,12 @@ Date,Label,Amount,Type,MainCategory,SubCategory
     )
 
     # And a file for balance
-    balance_file = cfg.root_dir / "balance.xxx.csv"
+    balance_file = cfg.root_dir / "balance.xxx.EUR.csv"
     balance_file.write_text(
         """\
 Date,Amount
-2019-08-29,300.0
-2019-09-01,200.0
+2019-08-29,300.00
+2019-09-01,200.00
 """
     )
 
@@ -87,9 +87,9 @@ Date,Label,Amount,Currency,Type,MainCategory,SubCategory
         balance_file.read_text()
         == """\
 Date,Amount,Currency
-2019-08-29,300.0,EUR
-2019-09-01,200.0,EUR
-2019-09-03,1000.0,EUR
+2019-08-29,300.00,EUR
+2019-09-01,200.00,EUR
+2019-09-03,1000.00,EUR
 """
     )
 
@@ -262,7 +262,7 @@ def test_boursorama_account_read_raw_account_2(cfg):
     assert_frame_equal(expected_transactions, actual_transactions)
 
 
-def test_boursorama_account_write_balance(cfg):
+def test_boursorama_account_insert_balance(cfg):
     with TemporaryDirectory() as d:
         # Given an existing CSV file with 2 rows
         csv = Path(d) / "balance.xxx.csv"
@@ -280,18 +280,18 @@ Date,Amount
             data=[(pd.Timestamp("2019-03-10"), 320.00, "EUR")],
         )
         account = BoursoramaAccount("type2", "name2", "003607")
-        BoursoramaBalancePipeline(account, cfg).write_balance(csv, new_lines)
+        actual_df = BoursoramaBalancePipeline(account, cfg).insert_balance(csv, new_lines)
 
         # Then rows are available and sorted
-        assert (
-            csv.read_text()
-            == """\
-Date,Amount,Currency
-2019-03-01,300.0,EUR
-2019-03-10,320.0,EUR
-2019-03-12,370.0,EUR
-"""
+        expected_df = pd.DataFrame(
+            columns=["Date", "Amount", "Currency"],
+            data=[
+                (pd.Timestamp("2019-03-01"), 300.00, "EUR"),
+                (pd.Timestamp("2019-03-10"), 320.00, "EUR"),
+                (pd.Timestamp("2019-03-12"), 370.00, "EUR"),
+            ],
         )
+        assert_frame_equal(actual_df, expected_df)
 
 
 def test_boursorama_pipeline_append_tx(cfg):

--- a/test/test_boursorama.py
+++ b/test/test_boursorama.py
@@ -262,7 +262,7 @@ def test_boursorama_account_read_raw_account_2(cfg):
     assert_frame_equal(expected_transactions, actual_transactions)
 
 
-def test_boursorama_account_write_balances(cfg):
+def test_boursorama_account_write_balance(cfg):
     with TemporaryDirectory() as d:
         # Given an existing CSV file with 2 rows
         csv = Path(d) / "balance.xxx.csv"
@@ -280,7 +280,7 @@ Date,Amount
             data=[(pd.Timestamp("2019-03-10"), 320.00, "EUR")],
         )
         account = BoursoramaAccount("type2", "name2", "003607")
-        BoursoramaBalancePipeline(account, cfg).write_balances(csv, new_lines)
+        BoursoramaBalancePipeline(account, cfg).write_balance(csv, new_lines)
 
         # Then rows are available and sorted
         assert (

--- a/test/test_main.py
+++ b/test/test_main.py
@@ -158,6 +158,11 @@ categories_to_rename:
 auto-complete:
 
 download-dir: {download_dir}
+
+exchange-rate:
+  watched-currencies:
+    - USD
+    - CNY
 """
         )
 
@@ -234,6 +239,11 @@ categories_to_rename:
 auto-complete:
 
 download-dir: {download_dir}
+
+exchange-rate:
+  watched-currencies:
+    - USD
+    - CNY
 """
         )
 
@@ -268,7 +278,7 @@ Date opération;Date valeur;libellé;Débit;Crédit;
     assert (root_dir / "2019-06" / "2019-06.credit-BNP-P15.csv").exists()
     assert (root_dir / "2019-04" / "2019-04.astark-FTN-CHQ.csv").exists()
     assert (root_dir / "2019-12" / "2019-12.astark-FTN-CHQ.csv").exists()
-    assert (root_dir / "balance.credit-BNP-P15.csv").exists()
+    assert (root_dir / "balance.credit-BNP-P15.EUR.csv").exists()
     assert csv.exists()
     assert download_fortuneo.exists()
     # And a summary is printed to standard output (stdout)
@@ -287,7 +297,7 @@ Targets:
 - {tmpdir.strpath}/finance/2019-04/2019-04.astark-FTN-CHQ.csv
 - {tmpdir.strpath}/finance/2019-06/2019-06.credit-BNP-P15.csv
 - {tmpdir.strpath}/finance/2019-12/2019-12.astark-FTN-CHQ.csv
-- {tmpdir.strpath}/finance/balance.credit-BNP-P15.csv
+- {tmpdir.strpath}/finance/balance.credit-BNP-P15.EUR.csv
 Finished.
 """
     )

--- a/test/test_revolut.py
+++ b/test/test_revolut.py
@@ -166,7 +166,7 @@ Date,Label,Amount,Currency,Type,MainCategory,SubCategory
 """
     )
 
-    balances = cfg.root_dir / "balance.user-REV-EUR.csv"
+    balances = cfg.root_dir / "balance.user-REV-EUR.EUR.csv"
     balances.write_text(
         """\
 Date,Amount,Currency
@@ -194,7 +194,7 @@ Date,Amount,Currency
         balances.read_text()
         == """\
 Date,Amount,Currency
-2021-01-01 00:00:00,10.0,EUR
+2021-01-01 00:00:00,10.00,EUR
 2021-01-05 14:00:41,74.43,EUR
 """
     )
@@ -227,7 +227,7 @@ Date,Label,Amount,Type,MainCategory,SubCategory
 """
     )
 
-    balances = cfg.root_dir / "balance.user-REV-EUR.csv"
+    balances = cfg.root_dir / "balance.user-REV-EUR.EUR.csv"
     balances.write_text(
         """\
 Date,Amount
@@ -255,7 +255,7 @@ Date,Amount
         balances.read_text()
         == """\
 Date,Amount,Currency
-2021-01-01 00:00:00,10.0,EUR
+2021-01-01 00:00:00,10.00,EUR
 2021-01-05 14:00:41,74.43,EUR
 """
     )


### PR DESCRIPTION
This PR introduces the new concept of exchange rates in the Finance Toolkit. In the past, we added the notion of currency at account level (see issue https://github.com/mincong-h/finance-toolkit/issues/56), meaning that each account has its concurrency, e.g. EUR, USD, and the system attaches the unit to the related files. This PR makes one step forward to convert a concurrency to another currency, which facilitates the data aggregation of multiple accounts. The currencies to pick up are configured in the configuration file (finance-tools.yaml) under the section "exchange-rate".