### PR TITLE
Change regex for exchange rate

### DIFF
--- a/finance_toolkit/tx.py
+++ b/finance_toolkit/tx.py
@@ -247,7 +247,7 @@ def move(cfg: Configuration):
                 factory.new_transaction_pipeline(account).run(path, summary)
                 factory.new_balance_pipeline(account).run(path, summary)
 
-        if re.match(r'Webstat_Export_(\d+)\.csv', path.name):
+        if re.match(r'Webstat_Export_(.+)\.csv', path.name):
             factory.new_exchange_rate_pipeline().run(path, summary)
     print(summary)
 


### PR DESCRIPTION
The Bank of France has changed the file name for the exchange rate from the format "Webstat_Export_5385698.csv" to "Webstat_Export_fr_5385698.csv", which includes the language in the filename. This PR adjusts the regular expression for it.