### PR TITLE
Support multi platform build

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -2,9 +2,6 @@ name: Actions
 
 on: [push]
 
-env:
-  DOCKER_BUILDKIT: 1
-
 jobs:
   test:
     runs-on: ubuntu-latest
@@ -61,6 +58,10 @@ jobs:
       with:
         username: ${{ secrets.DOCKER_USERNAME }}
         password: ${{ secrets.DOCKER_PASSWORD }}
+    - name: Set up QEMU
+      uses: docker/setup-qemu-action@v3
+    - name: Set up Docker Buildx
+      uses: docker/setup-buildx-action@v3
     - name: Build Docker image
       run: bin/docker-build.sh
     - name: Push Docker image

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -2,6 +2,9 @@ name: Actions
 
 on: [push]
 
+env:
+  DOCKER_BUILDKIT: 1
+
 jobs:
   test:
     runs-on: ubuntu-latest

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -62,7 +62,5 @@ jobs:
       uses: docker/setup-qemu-action@v3
     - name: Set up Docker Buildx
       uses: docker/setup-buildx-action@v3
-    - name: Build Docker image
+    - name: Build and Push Docker image
       run: bin/docker-build.sh
-    - name: Push Docker image
-      run: bin/docker-push.sh

--- a/bin/docker-build.sh
+++ b/bin/docker-build.sh
@@ -8,7 +8,7 @@ short_commit="$(git rev-parse --short HEAD)"
 pipeline_id="${GITHUB_RUN_ID:-0}"
 tag="v${pipeline_id}-${short_commit}"
 
-docker build \
+docker buildx build \
   --tag "mc144/finance-toolkit:${tag}" \
   --tag "mc144/finance-toolkit:latest" \
   --platform linux/amd64,linux/arm64 \

--- a/bin/docker-build.sh
+++ b/bin/docker-build.sh
@@ -11,4 +11,5 @@ tag="v${pipeline_id}-${short_commit}"
 docker build \
   --tag "mc144/finance-toolkit:${tag}" \
   --tag "mc144/finance-toolkit:latest" \
+  --platform linux/amd64,linux/arm64 \
   "$project_dir"

--- a/bin/docker-build.sh
+++ b/bin/docker-build.sh
@@ -8,8 +8,9 @@ short_commit="$(git rev-parse --short HEAD)"
 pipeline_id="${GITHUB_RUN_ID:-0}"
 tag="v${pipeline_id}-${short_commit}"
 
-docker buildx build \
+docker build \
   --tag "mc144/finance-toolkit:${tag}" \
   --tag "mc144/finance-toolkit:latest" \
   --platform linux/amd64,linux/arm64 \
+  --push \
   "$project_dir"

--- a/bin/docker-push.sh
+++ b/bin/docker-push.sh
@@ -1,9 +1,0 @@
-#!/bin/bash
-set -euxo pipefail
-
-short_commit="$(git rev-parse --short HEAD)"
-pipeline_id="${GITHUB_RUN_ID:-0}"
-tag="v${pipeline_id}-${short_commit}"
-
-docker push "mc144/finance-toolkit:${tag}"
-docker push "mc144/finance-toolkit:latest"


### PR DESCRIPTION
## Description

When running the CLI with Docker on macOS, it raises warning

> WARNING: The requested image's platform (linux/amd64) does not match the detected host platform (linux/arm64/v8) and no specific platform was requested

This is because the docker image is not built for arm. This PR fixes it by introducing a multi platform build. See also https://docs.docker.com/build/ci/github-actions/multi-platform/


## Testing

![image](https://github.com/user-attachments/assets/927e6b3d-ddf9-4774-98fe-d5f6a317a986)
