### PR TITLE
feat: use 'unknown' as default category for unmatched transactions

### DIFF
--- a/finance_toolkit/fortuneo.py
+++ b/finance_toolkit/fortuneo.py
@@ -70,8 +70,8 @@ class FortuneoTransactionPipeline(TransactionPipeline):
         # Fortuneo does not provide currency information explicitly, so we create it ourselves.
         tx = tx.assign(Currency=lambda row: self.account.currency_symbol)
         tx["Type"] = ""
-        tx["MainCategory"] = ""
-        tx["SubCategory"] = ""
+        tx["MainCategory"] = "unknown"
+        tx["SubCategory"] = "unknown"
 
         del tx["Date valeur"]
         del tx["empty"]

--- a/finance_toolkit/pipeline.py
+++ b/finance_toolkit/pipeline.py
@@ -32,9 +32,9 @@ class TransactionPipeline(Pipeline, metaclass=ABCMeta):
 
         # add custom columns if needed
         if "MainCategory" not in tx.columns:
-            tx["MainCategory"] = ""
+            tx["MainCategory"] = "unknown"
         if "SubCategory" not in tx.columns:
-            tx["SubCategory"] = ""
+            tx["SubCategory"] = "unknown"
         if "Type" not in tx.columns:
             tx["Type"] = ""
 

--- a/finance_toolkit/revolut.py
+++ b/finance_toolkit/revolut.py
@@ -92,8 +92,8 @@ class RevolutPipeline(Pipeline, metaclass=ABCMeta):
         )
 
         # TODO can we remove these fields?
-        tx["MainCategory"] = ""
-        tx["SubCategory"] = ""
+        tx["MainCategory"] = "unknown"
+        tx["SubCategory"] = "unknown"
 
         return balances, tx
 

--- a/test/test_bnp.py
+++ b/test/test_bnp.py
@@ -61,7 +61,7 @@ Date,Label,Amount,Type,MainCategory,SubCategory
         == """\
 Date,Label,Amount,Currency,Type,MainCategory,SubCategory
 2018-08-30,myLabel,-0.49,EUR,expense,main,sub
-2018-08-31,myLabel,-0.99,EUR,expense,,
+2018-08-31,myLabel,-0.99,EUR,expense,unknown,unknown
 """
     )
     assert (
@@ -69,7 +69,7 @@ Date,Label,Amount,Currency,Type,MainCategory,SubCategory
         == """\
 Date,Label,Amount,Currency,Type,MainCategory,SubCategory
 2018-09-01,myLabel,-1.49,EUR,expense,main,sub
-2018-09-02,myLabel,-2.49,EUR,expense,,
+2018-09-02,myLabel,-2.49,EUR,expense,unknown,unknown
 """
     )
 

--- a/test/test_boursorama.py
+++ b/test/test_boursorama.py
@@ -69,7 +69,7 @@ dateOp;dateVal;Label;category;categoryParent;Amount;accountNum;accountLabel;acco
         == """\
 Date,Label,Amount,Currency,Type,MainCategory,SubCategory
 2019-08-29,VIR Virement interne depuis BOURSORA,30.0,EUR,transfer,,
-2019-08-30,VIR Virement interne depuis BOURSORA,10.0,EUR,transfer,,
+2019-08-30,VIR Virement interne depuis BOURSORA,10.0,EUR,transfer,unknown,unknown
 """
     )
     assert (
@@ -77,7 +77,7 @@ Date,Label,Amount,Currency,Type,MainCategory,SubCategory
         == """\
 Date,Label,Amount,Currency,Type,MainCategory,SubCategory
 2019-09-01,VIR Virement interne depuis BOURSORA,40.0,EUR,transfer,,
-2019-09-02,VIR Virement interne depuis BOURSORA,11.0,EUR,transfer,,
+2019-09-02,VIR Virement interne depuis BOURSORA,11.0,EUR,transfer,unknown,unknown
 """
     )
 

--- a/test/test_fortuneo.py
+++ b/test/test_fortuneo.py
@@ -24,8 +24,8 @@ def test_fortuneo_transaction_pipeline_read_new_transactions(cfg):
             -6.4,
             "EUR",
             "",
-            "",
-            "",
+            "unknown",
+            "unknown",
         ),
         (
             pd.Timestamp("2019-12-13"),
@@ -33,8 +33,8 @@ def test_fortuneo_transaction_pipeline_read_new_transactions(cfg):
             -10.9,
             "EUR",
             "",
-            "",
-            "",
+            "unknown",
+            "unknown",
         ),
         (
             pd.Timestamp("2019-12-13"),
@@ -42,8 +42,8 @@ def test_fortuneo_transaction_pipeline_read_new_transactions(cfg):
             -45.59,
             "EUR",
             "",
-            "",
-            "",
+            "unknown",
+            "unknown",
         ),
         (
             pd.Timestamp("2019-12-12"),
@@ -51,8 +51,8 @@ def test_fortuneo_transaction_pipeline_read_new_transactions(cfg):
             -15.75,
             "EUR",
             "",
-            "",
-            "",
+            "unknown",
+            "unknown",
         ),
         (
             pd.Timestamp("2019-04-30"),
@@ -60,8 +60,8 @@ def test_fortuneo_transaction_pipeline_read_new_transactions(cfg):
             45.0,
             "EUR",
             "",
-            "",
-            "",
+            "unknown",
+            "unknown",
         ),
     ]
     expected = pd.DataFrame(
@@ -169,7 +169,7 @@ def test_run(cfg):
         tx201904.read_text()
         == """\
 Date,Label,Amount,Currency,Type,MainCategory,SubCategory
-2019-04-30,VIR MALAKOFF MEDERIC PREVOYANCE,45.0,EUR,,,
+2019-04-30,VIR MALAKOFF MEDERIC PREVOYANCE,45.0,EUR,,unknown,unknown
 """
     )
     tx201912 = cfg.root_dir / "2019-12" / "2019-12.astark-FTN-CHQ.csv"
@@ -177,10 +177,10 @@ Date,Label,Amount,Currency,Type,MainCategory,SubCategory
         tx201912.read_text()
         == """\
 Date,Label,Amount,Currency,Type,MainCategory,SubCategory
-2019-12-12,CARTE 11/12 LECLERC MARLY,-15.75,EUR,,,
-2019-12-13,CARTE 12/12 AMAZON EU SARL PAYLI2090401/,-45.59,EUR,,,
-2019-12-13,CARTE 12/12 BRIOCHE DOREE METZ,-10.9,EUR,,,
-2019-12-13,CARTE 12/12 FNAC METZ,-6.4,EUR,,,
+2019-12-12,CARTE 11/12 LECLERC MARLY,-15.75,EUR,,unknown,unknown
+2019-12-13,CARTE 12/12 AMAZON EU SARL PAYLI2090401/,-45.59,EUR,,unknown,unknown
+2019-12-13,CARTE 12/12 BRIOCHE DOREE METZ,-10.9,EUR,,unknown,unknown
+2019-12-13,CARTE 12/12 FNAC METZ,-6.4,EUR,,unknown,unknown
 """
     )
     assert (
@@ -261,8 +261,8 @@ def test_guess_meta(cfg):
                 -10.9,
                 "EUR",
                 "",
-                "",
-                "",
+                "unknown",
+                "unknown",
             ),
             (
                 pd.Timestamp("2019-12-13"),
@@ -288,8 +288,8 @@ def test_guess_meta(cfg):
                 45.0,
                 "EUR",
                 "",
-                "",
-                "",
+                "unknown",
+                "unknown",
             ),
         ],
     )

--- a/test/test_revolut.py
+++ b/test/test_revolut.py
@@ -52,8 +52,8 @@ def test_read_raw_2022_05_27_euro(cfg):
                 10.00,
                 "EUR",
                 "TOPUP",
-                "",
-                "",
+                "unknown",
+                "unknown",
             ),
             (
                 pd.Timestamp("2021-11-19 08:35:35"),
@@ -61,8 +61,8 @@ def test_read_raw_2022_05_27_euro(cfg):
                 -100.00,
                 "EUR",
                 "TRANSFER",
-                "",
-                "",
+                "unknown",
+                "unknown",
             ),
         ],
     )
@@ -146,8 +146,8 @@ def test_read_raw_pending_transactions(cfg):
                 -55.34,
                 "EUR",
                 "CARD_PAYMENT",
-                "",
-                "",
+                "unknown",
+                "unknown",
             ),
         ],
     )
@@ -208,7 +208,7 @@ Date,Amount,Currency
         == """\
 Date,Label,Amount,Currency,Type,MainCategory,SubCategory
 2021-01-01,This is an existing transaction,10.0,EUR,transfer,,
-2021-01-05,Payment from M  Huang Mincong,10.0,EUR,income,,
+2021-01-05,Payment from M  Huang Mincong,10.0,EUR,income,unknown,unknown
 """
     )
 
@@ -269,7 +269,7 @@ Date,Amount,Currency
         == """\
 Date,Label,Amount,Currency,Type,MainCategory,SubCategory
 2021-01-01,This is an existing transaction,10.0,EUR,transfer,,
-2021-01-05,Payment from M  Huang Mincong,10.0,EUR,income,,
+2021-01-05,Payment from M  Huang Mincong,10.0,EUR,income,unknown,unknown
 """
     )
 
@@ -339,6 +339,6 @@ Date,Amount,Currency
         == """\
 Date,Label,Amount,Currency,Type,MainCategory,SubCategory
 2024-01-02,This is an existing transaction,10.0,USD,transfer,,
-2024-01-05,Payment from M  Huang Mincong,10.0,USD,income,,
+2024-01-05,Payment from M  Huang Mincong,10.0,USD,income,unknown,unknown
 """
     )


### PR DESCRIPTION
## Summary
- Changed default category from empty strings to `unknown,unknown` for transactions without matching auto-complete rules
- Updated `pipeline.py`, `fortuneo.py`, and `revolut.py` to use "unknown" as the default value for MainCategory and SubCategory
- Makes it easier to identify transactions that need manual categorization

## Test plan
- [x] All 88 existing tests pass
- [x] Verified the changes work correctly for BNP, Boursorama, Fortuneo, Revolut, and Caisse d'Epargne pipelines

🤖 Generated with [Claude Code](https://claude.com/claude-code)