### PR TITLE
fix: skip balance pipeline for Caisse d'Epargne (no balance data in CSV)

### DIFF
--- a/finance_toolkit/caisse_epargne.py
+++ b/finance_toolkit/caisse_epargne.py
@@ -8,7 +8,7 @@ import pandas as pd
 from pandas import DataFrame
 
 from .account import Account
-from .models import Configuration, TxType
+from .models import Configuration, Summary, TxType
 from .pipeline import Pipeline, TransactionPipeline, BalancePipeline, PipelineDataError
 
 
@@ -106,6 +106,11 @@ class CaisseEpargneTransactionPipeline(CaisseEpargnePipeline, TransactionPipelin
 
 
 class CaisseEpargneBalancePipeline(CaisseEpargnePipeline, BalancePipeline):
+    def run(self, path: Path, summary: Summary) -> None:
+        # Caisse d'Epargne CSV exports don't contain balance information,
+        # so this pipeline does nothing.
+        pass
+
     def read_new_balances(self, csv: Path) -> DataFrame:
         balances, _ = self.read_raw(csv)
         return balances

--- a/test/test_caisse_epargne.py
+++ b/test/test_caisse_epargne.py
@@ -6,6 +6,7 @@ from pandas.testing import assert_frame_equal
 
 from finance_toolkit.caisse_epargne import (
     CaisseEpargneAccount,
+    CaisseEpargneBalancePipeline,
     CaisseEpargneTransactionPipeline,
 )
 from finance_toolkit.models import Summary, TxType
@@ -149,3 +150,27 @@ def test_caisse_epargne_transaction_pipeline_run(cfg):
     # And the summary is correct
     assert csv in summary.sources
     assert tx202411 in summary.targets
+
+
+def test_caisse_epargne_balance_pipeline_run_does_nothing(cfg):
+    """
+    Caisse d'Epargne CSV exports don't contain balance information,
+    so the balance pipeline should do nothing.
+    """
+    # Given a Caisse d'Epargne account and data file
+    account = CaisseEpargneAccount("CHQ", "test-CEP-CHQ", "12345678")
+    cfg.accounts.append(account)
+    csv = cfg.download_dir / "12345678_01112024_30112024.csv"
+    summary = Summary(cfg)
+    pipeline = CaisseEpargneBalancePipeline(account, cfg)
+
+    # When running the balance pipeline
+    pipeline.run(csv, summary)
+
+    # Then no balance file is created
+    balance_file = cfg.root_dir / account.balance_filename
+    assert not balance_file.exists()
+
+    # And the summary is not updated (no sources or targets added)
+    assert csv not in summary.sources
+    assert len(summary.targets) == 0

--- a/test/test_pipeline.py
+++ b/test/test_pipeline.py
@@ -11,6 +11,11 @@ from finance_toolkit.boursorama import (
     BoursoramaBalancePipeline,
     BoursoramaTransactionPipeline,
 )
+from finance_toolkit.caisse_epargne import (
+    CaisseEpargneAccount,
+    CaisseEpargneBalancePipeline,
+    CaisseEpargneTransactionPipeline,
+)
 from finance_toolkit.fortuneo import FortuneoAccount, FortuneoTransactionPipeline
 from finance_toolkit.pipeline import GeneralBalancePipeline, NoopTransactionPipeline
 from finance_toolkit.revolut import (
@@ -43,6 +48,9 @@ def test_new_transaction_pipeline(cfg):
             patterns=["unknown"],
         )
     )
+    p5 = PipelineFactory(cfg).new_transaction_pipeline(
+        CaisseEpargneAccount("CHQ", "foo-CEP-CHQ", "12345678")
+    )
     p_r1 = PipelineFactory(cfg).new_transaction_pipeline(
         RevolutAccount(
             account_type=RevolutAccount.TYPE_CASH,
@@ -72,6 +80,7 @@ def test_new_transaction_pipeline(cfg):
     assert isinstance(p2, BoursoramaTransactionPipeline)
     assert isinstance(p3, FortuneoTransactionPipeline)
     assert isinstance(p4, NoopTransactionPipeline)
+    assert isinstance(p5, CaisseEpargneTransactionPipeline)
     assert isinstance(p_r1, RevolutTransactionPipeline)
     assert isinstance(p_r2, RevolutTransactionPipeline)
     assert isinstance(p_r3, NoopTransactionPipeline)
@@ -92,6 +101,9 @@ def test_new_balance_pipeline(cfg):
             currency="EUR",
             patterns=["unknown"],
         )
+    )
+    p4 = PipelineFactory(cfg).new_balance_pipeline(
+        CaisseEpargneAccount("CHQ", "foo-CEP-CHQ", "12345678")
     )
     p_r1 = PipelineFactory(cfg).new_balance_pipeline(
         RevolutAccount(
@@ -121,6 +133,7 @@ def test_new_balance_pipeline(cfg):
     assert isinstance(p1, BnpBalancePipeline)
     assert isinstance(p2, BoursoramaBalancePipeline)
     assert isinstance(p3, GeneralBalancePipeline)
+    assert isinstance(p4, CaisseEpargneBalancePipeline)
     assert isinstance(p_r1, RevolutBalancePipeline)
     assert isinstance(p_r2, RevolutBalancePipeline)
     assert isinstance(p_r3, GeneralBalancePipeline)


### PR DESCRIPTION
## Summary
- Fix `KeyError: 'Date'` when running `move` command with Caisse d'Epargne accounts
- Caisse d'Epargne CSV exports only contain transaction data, not balance information
- The balance pipeline now skips processing (like `GeneralBalancePipeline`)

## Test plan
- [x] All 88 existing tests pass
- [x] flake8 passes
- [ ] Manual test with `finance-toolkit.sh move` on Caisse d'Epargne files

🤖 Generated with [Claude Code](https://claude.com/claude-code)